### PR TITLE
Disable resource locker in Solid server config

### DIFF
--- a/templates/server-config.json
+++ b/templates/server-config.json
@@ -29,7 +29,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/memory.json",
+    "css:config/util/resource-locker/debug-void.json",
     "css:config/util/variables/default.json"
   ],
   "comment": "Adapted from \"css:config/file-no-setup.json\"",


### PR DESCRIPTION
When serving the generated dataset, the Community Solid Server sometimes outputs errors like:
```
2023-07-10T08:54:40.266Z [WrappedExpiringReadWriteLocker] {Primary} error: Lock expired after 6000ms on http://localhost:3000/pods/00000002199023256816/comments/India
2023-07-10T08:54:40.268Z [StreamUtil] {W-???} warn: Piped stream errored with Lock expired after 6000ms on http://localhost:3000/pods/00000002199023256816/comments/India
2023-07-10T08:54:40.269Z [BasicResponseWriter] {Primary} error: Aborting streaming response because of server error; headers already sent.
2023-07-10T08:54:40.269Z [BasicResponseWriter] {Primary} error: Response error: Lock expired after 6000ms on http://localhost:3000/pods/00000002199023256816/comments/India
```
These seem to be related to locks expiring, but when data is being served within SolidBench, it is intended for read-only purposes and should not need locks. The configuration change in this pull request makes the SolidBench server configuration use a locker for the server that does not actually do anything, removing those lock errors. Maybe this is not the best solution, but it seems to work.