### PR TITLE
Update CSS to version 6, update ESLint configs and add Node 18 to CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,8 @@ module.exports = {
                 }
             }
         ],
+        'import/group-exports': 'off',
+        'import/newline-after-import': 'off',
+        'import/no-nodejs-modules': 'off',
     }
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         node-version:
           - 14.x
           - 16.x
+          - 18.x
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           key: ${{ runner.os }}-lint-modules-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 18.x
       - run: yarn install --frozen-lockfile
       - run: yarn run lint
 
@@ -22,9 +22,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version:
-          - 14.x
-          - 16.x
           - 18.x
+          - 20.x
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 18.x
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-engines
       - run: yarn run lint
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn run lint
 
   test:
@@ -39,7 +39,7 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-test-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
-        run: yarn install
+        run: yarn install  --frozen-lockfile --ignore-engines
       - name: Build project
         run: yarn run build
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This benchmark is based on the [LDBC SNB](https://github.com/ldbc/ldbc_snb_datag
 
 ## Requirements
 
-* [Node.js](https://nodejs.org/en/) _(1.14 or higher)_
+* [Node.js](https://nodejs.org/en/) _(15 or higher)_
 * [Docker](https://www.docker.com/) _(required for invoking [LDBC SNB generator](https://github.com/ldbc/ldbc_snb_datagen_hadoop))_
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install -g solidbench
 ```
 or
 ```bash
-$ yarn global add solidbench
+$ yarn global add solidbench --ignore-engines
 ```
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This benchmark is based on the [LDBC SNB](https://github.com/ldbc/ldbc_snb_datag
 
 ## Requirements
 
-* [Node.js](https://nodejs.org/en/) _(15 or higher)_
+* [Node.js](https://nodejs.org/en/) _(16 or higher)_
 * [Docker](https://www.docker.com/) _(required for invoking [LDBC SNB generator](https://github.com/ldbc/ldbc_snb_datagen_hadoop))_
 
 ## Installation

--- a/lib/Generator.ts
+++ b/lib/Generator.ts
@@ -97,9 +97,7 @@ export class Generator {
     // Create params.ini file
     const paramsTemplate = await fs.promises.readFile(Path.join(__dirname, '../templates/params.ini'), 'utf8');
     const paramsPath = Path.join(this.cwd, 'params.ini');
-    // TODO: remove once we drop Node 14 support
-    // eslint-disable-next-line unicorn/prefer-string-replace-all
-    await fs.promises.writeFile(paramsPath, paramsTemplate.replace(/SCALE/ug, this.scale), 'utf8');
+    await fs.promises.writeFile(paramsPath, paramsTemplate.replaceAll('SCALE', this.scale), 'utf8');
 
     // Pull the base Docker image
     const dockerode = new Dockerode();

--- a/package.json
+++ b/package.json
@@ -90,25 +90,16 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@rubensworks/eslint-config": "^1.0.1",
+    "@rubensworks/eslint-config": "^2.0.0",
     "@types/jest": "^26.0.0",
-    "@types/node": "^14.14.7",
-    "@typescript-eslint/eslint-plugin": "^4.2.0",
-    "@typescript-eslint/parser": "^4.1.1",
     "coveralls": "^3.0.0",
     "eslint": "^7.9.0",
-    "eslint-config-es": "^3.23.0",
-    "eslint-import-resolver-typescript": "^2.3.0",
-    "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-jest": "^24.0.2",
-    "eslint-plugin-tsdoc": "^0.2.7",
-    "eslint-plugin-unused-imports": "^0.1.3",
     "fs-extra": "^9.0.0",
     "husky": "^4.2.5",
     "jest": "^26.6.3",
     "jest-extended": "^0.11.2",
     "manual-git-changelog": "^1.0.1",
-    "rimraf": "latest",
+    "rimraf": "^5.0.1",
     "ts-jest": "^26.4.3",
     "typescript": "^4.6.4"
   }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "index.ts"
   ],
   "dependencies": {
-    "@solid/community-server": "^5.0.0-alpha.0",
+    "@solid/community-server": "^6.0.2",
     "@types/dockerode": "^3.2.3",
     "@types/unzipper": "^0.10.5",
     "@types/yargs": "^16.0.1",

--- a/templates/server-config.json
+++ b/templates/server-config.json
@@ -1,13 +1,13 @@
 {
-  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^6.0.0/components/context.jsonld",
   "import": [
     "css:config/app/main/default.json",
-
     "css:config/app/setup/disabled.json",
     "css:config/app/variables/default.json",
     "css:config/http/handler/default.json",
-    "css:config/http/middleware/websockets.json",
-    "css:config/http/server-factory/websockets.json",
+    "css:config/http/middleware/default.json",
+    "css:config/http/notifications/websockets.json",
+    "css:config/http/server-factory/http.json",
     "css:config/http/static/default.json",
     "css:config/identity/access/public.json",
     "css:config/identity/email/default.json",
@@ -24,8 +24,7 @@
     "css:config/storage/backend/file.json",
     "css:config/storage/key-value/memory.json",
     "css:config/storage/middleware/default.json",
-    "css:config/util/auxiliary/no-acl.json",
-
+    "css:config/util/auxiliary/empty.json",
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
@@ -37,7 +36,6 @@
     {
       "comment": "A single-pod server that stores its resources on disk."
     },
-
     { "comment": "Adapted from \"css:config/app/init/initialize-root.json\", with things removed" },
     {
       "import": [
@@ -52,8 +50,6 @@
         { "@id": "urn:solid-server:default:ServerInitializer" }
       ]
     },
-
-
     { "comment": "Adapted from \"css:config/util/identifiers/suffix.json\", with FixedContentTypeMapper" },
     {
       "@id": "urn:solid-server:default:IdentifierStrategy",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,17 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@^2.1.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
-  integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
+"@aashutoshrathi/word-wrap@^1.2.3":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
+  integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
+
+"@ampproject/remapping@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
+  integrity sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==
   dependencies:
-    "@jridgewell/gen-mapping" "^0.1.0"
+    "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@babel/code-frame@7.12.11":
@@ -17,164 +22,164 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
-  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.22.10", "@babel/code-frame@^7.22.5":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
+  integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
   dependencies:
-    "@babel/highlight" "^7.18.6"
+    "@babel/highlight" "^7.22.13"
+    chalk "^2.4.2"
 
-"@babel/compat-data@^7.20.0":
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.5.tgz#86f172690b093373a933223b4745deeb6049e733"
-  integrity sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==
+"@babel/compat-data@^7.22.9":
+  version "7.22.9"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
+  integrity sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==
 
 "@babel/core@^7.1.0", "@babel/core@^7.12.16", "@babel/core@^7.12.3", "@babel/core@^7.7.5":
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.5.tgz#45e2114dc6cd4ab167f81daf7820e8fa1250d113"
-  integrity sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.22.11.tgz#8033acaa2aa24c3f814edaaa057f3ce0ba559c24"
+  integrity sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==
   dependencies:
-    "@ampproject/remapping" "^2.1.0"
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.20.5"
-    "@babel/helper-compilation-targets" "^7.20.0"
-    "@babel/helper-module-transforms" "^7.20.2"
-    "@babel/helpers" "^7.20.5"
-    "@babel/parser" "^7.20.5"
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.20.5"
-    "@babel/types" "^7.20.5"
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.22.10"
+    "@babel/generator" "^7.22.10"
+    "@babel/helper-compilation-targets" "^7.22.10"
+    "@babel/helper-module-transforms" "^7.22.9"
+    "@babel/helpers" "^7.22.11"
+    "@babel/parser" "^7.22.11"
+    "@babel/template" "^7.22.5"
+    "@babel/traverse" "^7.22.11"
+    "@babel/types" "^7.22.11"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
-    json5 "^2.2.1"
-    semver "^6.3.0"
+    json5 "^2.2.3"
+    semver "^6.3.1"
 
 "@babel/eslint-parser@^7.12.16":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz#4f68f6b0825489e00a24b41b6a1ae35414ecd2f4"
-  integrity sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.22.11.tgz#cceb8c7989c241a16dd14e12a6cd725618f3f58b"
+  integrity sha512-YjOYZ3j7TjV8OhLW6NCtyg8G04uStATEUe5eiLuCZaXz2VSDQ3dsAtm2D+TuQyAqNMUK2WacGo0/uma9Pein1w==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
-    semver "^6.3.0"
+    semver "^6.3.1"
 
-"@babel/generator@^7.20.5":
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.5.tgz#cb25abee3178adf58d6814b68517c62bdbfdda95"
-  integrity sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==
+"@babel/generator@^7.22.10":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.10.tgz#c92254361f398e160645ac58831069707382b722"
+  integrity sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==
   dependencies:
-    "@babel/types" "^7.20.5"
+    "@babel/types" "^7.22.10"
     "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
-"@babel/helper-compilation-targets@^7.20.0":
-  version "7.20.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz#6bf5374d424e1b3922822f1d9bdaa43b1a139d0a"
-  integrity sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==
+"@babel/helper-compilation-targets@^7.22.10":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz#01d648bbc25dd88f513d862ee0df27b7d4e67024"
+  integrity sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==
   dependencies:
-    "@babel/compat-data" "^7.20.0"
-    "@babel/helper-validator-option" "^7.18.6"
-    browserslist "^4.21.3"
-    semver "^6.3.0"
+    "@babel/compat-data" "^7.22.9"
+    "@babel/helper-validator-option" "^7.22.5"
+    browserslist "^4.21.9"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
 
-"@babel/helper-environment-visitor@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
-  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
+"@babel/helper-environment-visitor@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz#f06dd41b7c1f44e1f8da6c4055b41ab3a09a7e98"
+  integrity sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==
 
-"@babel/helper-function-name@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
-  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
+"@babel/helper-function-name@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz#ede300828905bb15e582c037162f99d5183af1be"
+  integrity sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==
   dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/types" "^7.19.0"
+    "@babel/template" "^7.22.5"
+    "@babel/types" "^7.22.5"
 
-"@babel/helper-hoist-variables@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
-  integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
+"@babel/helper-hoist-variables@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz#c01a007dac05c085914e8fb652b339db50d823bb"
+  integrity sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==
   dependencies:
-    "@babel/types" "^7.18.6"
+    "@babel/types" "^7.22.5"
 
-"@babel/helper-module-imports@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
-  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+"@babel/helper-module-imports@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz#1a8f4c9f4027d23f520bd76b364d44434a72660c"
+  integrity sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==
   dependencies:
-    "@babel/types" "^7.18.6"
+    "@babel/types" "^7.22.5"
 
-"@babel/helper-module-transforms@^7.20.2":
-  version "7.20.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz#ac53da669501edd37e658602a21ba14c08748712"
-  integrity sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==
+"@babel/helper-module-transforms@^7.22.9":
+  version "7.22.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz#92dfcb1fbbb2bc62529024f72d942a8c97142129"
+  integrity sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==
   dependencies:
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-module-imports" "^7.18.6"
-    "@babel/helper-simple-access" "^7.20.2"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.19.1"
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.20.1"
-    "@babel/types" "^7.20.2"
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-module-imports" "^7.22.5"
+    "@babel/helper-simple-access" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/helper-validator-identifier" "^7.22.5"
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.20.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
-  integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
+  integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
 
-"@babel/helper-simple-access@^7.20.2":
-  version "7.20.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz#0ab452687fe0c2cfb1e2b9e0015de07fc2d62dd9"
-  integrity sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==
+"@babel/helper-simple-access@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz#4938357dc7d782b80ed6dbb03a0fba3d22b1d5de"
+  integrity sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==
   dependencies:
-    "@babel/types" "^7.20.2"
+    "@babel/types" "^7.22.5"
 
-"@babel/helper-split-export-declaration@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
-  integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
+"@babel/helper-split-export-declaration@^7.22.6":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz#322c61b7310c0997fe4c323955667f18fcefb91c"
+  integrity sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==
   dependencies:
-    "@babel/types" "^7.18.6"
+    "@babel/types" "^7.22.5"
 
-"@babel/helper-string-parser@^7.19.4":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
-  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
 
-"@babel/helper-validator-identifier@^7.14.9", "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
-  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+"@babel/helper-validator-identifier@^7.14.9", "@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
-"@babel/helper-validator-option@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
-  integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
+"@babel/helper-validator-option@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz#de52000a15a177413c8234fa3a8af4ee8102d0ac"
+  integrity sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==
 
-"@babel/helpers@^7.20.5":
-  version "7.20.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.6.tgz#e64778046b70e04779dfbdf924e7ebb45992c763"
-  integrity sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==
+"@babel/helpers@^7.22.11":
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.22.11.tgz#b02f5d5f2d7abc21ab59eeed80de410ba70b056a"
+  integrity sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==
   dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.20.5"
-    "@babel/types" "^7.20.5"
+    "@babel/template" "^7.22.5"
+    "@babel/traverse" "^7.22.11"
+    "@babel/types" "^7.22.11"
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
-  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.22.13":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.13.tgz#9cda839e5d3be9ca9e8c26b6dd69e7548f0cbf16"
+  integrity sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.18.6"
-    chalk "^2.0.0"
+    "@babel/helper-validator-identifier" "^7.22.5"
+    chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.20.5":
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.5.tgz#7f3c7335fe417665d929f34ae5dceae4c04015e8"
-  integrity sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.11", "@babel/parser@^7.22.5":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.13.tgz#23fb17892b2be7afef94f573031c2f4b42839a2b"
+  integrity sha512-3l6+4YOvc9wx7VlCSw4yQfcBo01ECA8TicQfbnCPuCEpRQrf+gTUyGdxNw+pyTUyywp6JRD1w0YQs9TpBXYlkw==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -260,38 +265,38 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/template@^7.18.10", "@babel/template@^7.3.3":
-  version "7.18.10"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
-  integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
+"@babel/template@^7.22.5", "@babel/template@^7.3.3":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.5.tgz#0c8c4d944509875849bd0344ff0050756eefc6ec"
+  integrity sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.18.10"
-    "@babel/types" "^7.18.10"
+    "@babel/code-frame" "^7.22.5"
+    "@babel/parser" "^7.22.5"
+    "@babel/types" "^7.22.5"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5":
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.5.tgz#78eb244bea8270fdda1ef9af22a5d5e5b7e57133"
-  integrity sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.22.11":
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.11.tgz#71ebb3af7a05ff97280b83f05f8865ac94b2027c"
+  integrity sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.20.5"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.19.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.20.5"
-    "@babel/types" "^7.20.5"
+    "@babel/code-frame" "^7.22.10"
+    "@babel/generator" "^7.22.10"
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-function-name" "^7.22.5"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.22.11"
+    "@babel/types" "^7.22.11"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.19.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.5.tgz#e206ae370b5393d94dfd1d04cd687cace53efa84"
-  integrity sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.22.10", "@babel/types@^7.22.11", "@babel/types@^7.22.5", "@babel/types@^7.3.3":
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.11.tgz#0e65a6a1d4d9cbaa892b2213f6159485fe632ea2"
+  integrity sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==
   dependencies:
-    "@babel/helper-string-parser" "^7.19.4"
-    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
 "@balena/dockerignore@^1.0.2":
@@ -304,7 +309,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bergos/jsonparse@^1.4.1":
+"@bergos/jsonparse@^1.4.0", "@bergos/jsonparse@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@bergos/jsonparse/-/jsonparse-1.4.1.tgz#560e7125f65d0ad6b96dfe1c0d5da3115b9f8c59"
   integrity sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==
@@ -324,22 +329,6 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@comunica/actor-abstract-mediatyped@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz#9342e7d38c17c095e95c6afca7c7edee4830e81e"
-  integrity sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-
-"@comunica/actor-abstract-mediatyped@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.6.0.tgz#579e0be26f8533ec2271ad123b600eb7cc7a90ab"
-  integrity sha512-ghzdbvmoMpeJeK53cQG120KLSckpus9xr/nPbVAGCX3nnVWl+8rYE5MXjD+hqPusHWDguFVtqmGVzs1W3HX9Nw==
-  dependencies:
-    "@comunica/core" "^2.6.0"
-    "@comunica/types" "^2.6.0"
-
 "@comunica/actor-abstract-mediatyped@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.8.2.tgz#18265089afb5c0da7253a3476fd59d3193d98382"
@@ -347,14 +336,6 @@
   dependencies:
     "@comunica/core" "^2.8.2"
     "@comunica/types" "^2.8.2"
-
-"@comunica/actor-abstract-parse@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.5.1.tgz#6a2d9f23549e86c9f76acc92795235433ac3cbfa"
-  integrity sha512-KbkdI2QRH6gfVsDwufpj02jBSBMSG19xC1d52M1GG6MfdMoDNj2MLlcf0rXgYe1IePdCWf0qZzxqdu4fYQpYFw==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-    readable-stream "^4.2.0"
 
 "@comunica/actor-abstract-parse@^2.8.2":
   version "2.8.2"
@@ -390,15 +371,7 @@
     "@comunica/core" "^2.8.2"
     "@comunica/types" "^2.8.2"
 
-"@comunica/actor-dereference-fallback@^2.0.2":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.5.1.tgz#03301abb3aa56387f1b2f86349cc75a308a201cb"
-  integrity sha512-Yn3NFS73LV62QLYYzdGxTAROHr319D2RmNwXxkkz98oVFVkoWsWU+ojIA4n8yjceuHu0jXP5C0NNJIou+dR2lw==
-  dependencies:
-    "@comunica/bus-dereference" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-
-"@comunica/actor-dereference-fallback@^2.8.2":
+"@comunica/actor-dereference-fallback@^2.0.2", "@comunica/actor-dereference-fallback@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.8.2.tgz#8c128db4722b39918fe90dfad6d13b1a40bc9ec5"
   integrity sha512-XDEUN54hyX/phxzJQFbkemoO92CIwa30YHys6bQV1mtfy8oINqfpabFXNr9VSsMO3CpQE5FsfJfFWUD8vdcSVw==
@@ -407,26 +380,14 @@
     "@comunica/core" "^2.8.2"
 
 "@comunica/actor-dereference-file@^2.0.2":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-file/-/actor-dereference-file-2.5.1.tgz#f3380535ff81c01115fa0e445c2ecc66f92e0542"
-  integrity sha512-0+vnQ1KsTuRQRDz3vNSg23ohDS8oyY4zlsSIwyJAj1Ao4I5xhYtrt7h0up4o4hV2Qcy4ILoUGnVJzLaf0zCojQ==
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-file/-/actor-dereference-file-2.8.2.tgz#9ad2a92af9985836e396639130e9d3232463c38d"
+  integrity sha512-dzF4nQlNulno49xOG6O7n/O4wWKNAtEgqgU1UOSpmn2grxKB8FwtAZmWpIzGK9NlpX+xllehXpisvTivgrluTA==
   dependencies:
-    "@comunica/bus-dereference" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-dereference-http@^2.0.2":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-http/-/actor-dereference-http-2.5.1.tgz#83c0c2b9a15de1431308344b1092bb7e9fc1b16b"
-  integrity sha512-Vy9IyaNgygp5qFB14/FV6bt77JQJgOfEfMopyC2f8KcMWmFHdbuRPVCv83kme4wouB6d6L0mCvQ2yT6uWQf8qQ==
-  dependencies:
-    "@comunica/bus-dereference" "^2.5.1"
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    cross-fetch "^3.1.5"
-    relative-to-absolute-iri "^1.0.7"
-    stream-to-string "^1.2.0"
-
-"@comunica/actor-dereference-http@^2.8.2":
+"@comunica/actor-dereference-http@^2.0.2", "@comunica/actor-dereference-http@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-http/-/actor-dereference-http-2.8.2.tgz#90bea997db993d1223170b82043bef85d12add6f"
   integrity sha512-3yaGR+3o+t1avUYmgeZzvYqQvQ1fMGn2Ji0FrYuEwbx9Wty0kCr7jRjDYB4VyagwPx6lzQy0RVoNb6LbUNSiXA==
@@ -458,18 +419,7 @@
     hash.js "^1.1.7"
     rdf-string "^1.6.1"
 
-"@comunica/actor-http-fetch@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-2.5.1.tgz#c49e265bfc46e9d36ea8db9bdd53210f3ebf7ee5"
-  integrity sha512-2E25qKw2+16iWOHfaaGkbzv14owMwN3UGWURPaLyFIOa8S6xkjU/8CMWRjaGibee2KOC8TKUioeQ+YJCweIC/w==
-  dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/mediatortype-time" "^2.5.1"
-    abort-controller "^3.0.0"
-    cross-fetch "^3.1.5"
-
-"@comunica/actor-http-fetch@^2.8.2":
+"@comunica/actor-http-fetch@^2.0.1", "@comunica/actor-http-fetch@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-2.8.2.tgz#a9fd75cdcb684688394bb7fe35c99749b959732b"
   integrity sha512-XKPWbWihnBGPn3fnf7kxq2wVENDbCtTOl+9hFgsspoh1ew8fc0Fri85iE5dE5Z82s5PfW/oxQBFZVeiwKHwAZw==
@@ -480,17 +430,7 @@
     abort-controller "^3.0.0"
     cross-fetch "^4.0.0"
 
-"@comunica/actor-http-proxy@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-2.5.1.tgz#5139f23c087b768022f414303b49a62265eadb1d"
-  integrity sha512-VlBxLWgg0wC+xl3Ut8ZNSADHJZR472+VB8YI+MkQhU2uUvvt5eHUzaEu0QDY7K9sjEfbw+qh6plXCum1REOYhg==
-  dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/mediatortype-time" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-
-"@comunica/actor-http-proxy@^2.8.2":
+"@comunica/actor-http-proxy@^2.0.1", "@comunica/actor-http-proxy@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-2.8.2.tgz#aec3147132934649c969c7e586db390014e66b35"
   integrity sha512-OOFWfWVdi5mpRRgrNIqFx+C1wv3ulcDaBYojzbQdktwl6Vsz79Hlh3EHsgyTVxKHLjuhGeb/3aNbj2cFMVlF+A==
@@ -1455,16 +1395,7 @@
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-parse-html-microdata@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.5.1.tgz#8c1ac26084d67f6c63d8ba0b9042b5831e5bf9fd"
-  integrity sha512-hXpIwvBOjBLLM4ppEcu1wofjNRFavP33OHpK/Z5toOE1oyrLLtwJFpFxgc1zobhJibYuTskLlhkaCo4w5wVASA==
-  dependencies:
-    "@comunica/bus-rdf-parse-html" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    microdata-rdf-streaming-parser "^2.0.1"
-
-"@comunica/actor-rdf-parse-html-microdata@^2.8.2":
+"@comunica/actor-rdf-parse-html-microdata@^2.0.1", "@comunica/actor-rdf-parse-html-microdata@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.8.2.tgz#df447b1bcfc1641d1434424ec395267f6731241e"
   integrity sha512-vJOjT0xNpUpwqf46oZoXj4hjEK5FrstyjHeuVe1nJruPCE2QMDIdt/wcc9SP2T/Px5uvEjDUgEoxAEOPWkADAQ==
@@ -1473,16 +1404,7 @@
     "@comunica/core" "^2.8.2"
     microdata-rdf-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-rdfa@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.5.1.tgz#41baa95a097090f28e303f30bf235f285cd94d83"
-  integrity sha512-hGQ2cZC3glZVdyk4CbmLS5aDTCVHirDYqZ35484MsEipitp+bOJ9/Zg/oXRjs7DtqKmtgqUgw8FGn7dUgnzHPg==
-  dependencies:
-    "@comunica/bus-rdf-parse-html" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    rdfa-streaming-parser "^2.0.1"
-
-"@comunica/actor-rdf-parse-html-rdfa@^2.8.2":
+"@comunica/actor-rdf-parse-html-rdfa@^2.0.1", "@comunica/actor-rdf-parse-html-rdfa@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.8.2.tgz#37bee07c35b957994eec35f7178c263d7c3247b4"
   integrity sha512-Ipe5NWHZJsnGs8KZE1GbNIRIV5DyF+IOt4BR8z4QmQu1IjzkE2zFG/tT7hI4ZQ7jYjMwkW3xcfsK4FJp+MnhQQ==
@@ -1491,21 +1413,7 @@
     "@comunica/core" "^2.8.2"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-script@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.5.1.tgz#be5d51819e367c8b0483c65fdef147558cfb9350"
-  integrity sha512-GArg4XS6CHJbnkABYzVmyiWqNhmRHJdCUWWFMJeqYOPK5Smt5FRDdpDl0Pkh4mcUt0RBRTd0l9zW6AcuLK7iug==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^2.5.1"
-    "@comunica/bus-rdf-parse-html" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    "@rdfjs/types" "*"
-    readable-stream "^4.2.0"
-    relative-to-absolute-iri "^1.0.7"
-
-"@comunica/actor-rdf-parse-html-script@^2.8.2":
+"@comunica/actor-rdf-parse-html-script@^2.0.1", "@comunica/actor-rdf-parse-html-script@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.8.2.tgz#23c726a874c11eab204da16a092b9f63f4c19512"
   integrity sha512-4Y87tzHJREywzjCbS/A7lwPtrFXIdb6pEnyWK/UROsj8nw8M7UacKog6hyB0iyeZGPM43S9x0RC/u5RWA9PHrw==
@@ -1519,20 +1427,7 @@
     readable-stream "^4.2.0"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-rdf-parse-html@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.5.1.tgz#8d7f057b19bf756695d16ab351fcda9b9712b61e"
-  integrity sha512-2cbJ4YfII1Rvh7787/fA3OLn5+8mwp3qwiXQtxZEkuqRhsG635oUb4mQrKwywi3y2UzbK4i2fO2248qLK7HSgg==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^2.5.1"
-    "@comunica/bus-rdf-parse-html" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    "@rdfjs/types" "*"
-    htmlparser2 "^8.0.1"
-    readable-stream "^4.2.0"
-
-"@comunica/actor-rdf-parse-html@^2.8.2":
+"@comunica/actor-rdf-parse-html@^2.0.1", "@comunica/actor-rdf-parse-html@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.8.2.tgz#77a22e973465367386a615a2077e3211bfaf631d"
   integrity sha512-SV7iBGETX8igGyB84TVxM/2ylvugDAfDNgxkZPxuEjJfi65YHSt/pqnXPYYcuZ5QCO59gjBVMoeSIdNvmCHoOA==
@@ -1545,21 +1440,7 @@
     htmlparser2 "^9.0.0"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-parse-jsonld@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.5.1.tgz#092b7a3fcc308d71bc21d67fb19da3ae49d1f7b2"
-  integrity sha512-zJxVAxDQY6CCJCrWHO+07f0PK2DwlSU00hJO2n5Y+7lkicmcUcgSbVxE3CEI0/8aq/8p2jUcCEs++hgIpeArlg==
-  dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/bus-rdf-parse" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    jsonld-context-parser "^2.2.2"
-    jsonld-streaming-parser "^3.0.1"
-    stream-to-string "^1.2.0"
-
-"@comunica/actor-rdf-parse-jsonld@^2.8.2":
+"@comunica/actor-rdf-parse-jsonld@^2.0.1", "@comunica/actor-rdf-parse-jsonld@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.8.2.tgz#94d3e89fa3f733eb3f067bac1abb0a00d7fb34c5"
   integrity sha512-6H5HmiMujyISzxMAGWDjpMjWb1VD/GYw7Jzx6GWy6M9tjxcvkJRlgUl0dXOhIOlh/0LohrV18bKnA8uUcILzZw==
@@ -1573,16 +1454,7 @@
     jsonld-streaming-parser "^3.0.1"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-n3@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.5.1.tgz#43aa8acbb8b8e001ab503984d317f437432b673f"
-  integrity sha512-N6P7r2co80RFrjurldR+DCz7ajqj7Ck2QLuZhCaZZY2n6IBsfdt9QcYcuMlhykYjt+/u6tVQEuWj/XWQy6mpYQ==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    n3 "^1.16.3"
-
-"@comunica/actor-rdf-parse-n3@^2.8.2":
+"@comunica/actor-rdf-parse-n3@^2.0.1", "@comunica/actor-rdf-parse-n3@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.8.2.tgz#bc607db929bfbae18e1edd14db0377bb5916f39b"
   integrity sha512-vNbIA8MsZ4AGUTdxm1wcccjPyH4moMV2gGH3ZLhf2c7/zvVHbRiVcD7FB3ELU0yHUD9o5H9UBSwsmLMWQTSxcA==
@@ -1591,16 +1463,7 @@
     "@comunica/types" "^2.8.2"
     n3 "^1.17.0"
 
-"@comunica/actor-rdf-parse-rdfxml@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.5.1.tgz#23aab18d006996139a9e07eb2d3f11d1e4715b32"
-  integrity sha512-MKRSh3GIHXCOMHskcZPdggY7O5GkBfLNoNt4HYe+08jR9/Kib8rEfd4ErKi9mbuWJbXciA84HLt3ebZpmydaKA==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    rdfxml-streaming-parser "^2.2.1"
-
-"@comunica/actor-rdf-parse-rdfxml@^2.8.2":
+"@comunica/actor-rdf-parse-rdfxml@^2.0.1", "@comunica/actor-rdf-parse-rdfxml@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.8.2.tgz#3576c968f5ce3f3ea0fe1bd951f7bb3d4544ed0d"
   integrity sha512-5SoYBhrPicqHQKUTK20mYZqILctrIcxjk9R+tdhlAHzWOIT3Usmx87t2/5V8Tf/mr6ld9snQIaYS19QtU8MQYg==
@@ -1622,16 +1485,7 @@
     shaclc-parse "^1.4.0"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-xml-rdfa@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.5.1.tgz#4829f274f81560bd3b59869bbc94ec6e4f21681a"
-  integrity sha512-NbNaGcUepRz908nAVytKmTFn0dXOLdG88oD8ldI6Aw0HDvQU6Iw5r5eSaunfZONYYFT30eTZrGUyg3efwwfuvw==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    rdfa-streaming-parser "^2.0.1"
-
-"@comunica/actor-rdf-parse-xml-rdfa@^2.8.2":
+"@comunica/actor-rdf-parse-xml-rdfa@^2.0.1", "@comunica/actor-rdf-parse-xml-rdfa@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.8.2.tgz#99902af8794f6e98d1d2bf02db5fabb07aedf8a2"
   integrity sha512-8bGTXpDbUqNowoSmLXapC/4blKQHWicVoV5NfdTcCrB0Nxs+oHa3I5DJMShQ6EBwCWVaScYcCcGFWIvE2tQPyA==
@@ -1778,25 +1632,7 @@
     rdf-store-stream "^2.0.0"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-serialize-jsonld@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.5.1.tgz#b2b4924fc946cb4c6f11bf557462c1e9f452f585"
-  integrity sha512-QYyruMJBKYeIeTENMsBfCq3/fRUTlmMtOchRn0Hf8vWp+ZO5sx7EksvwA3hEJ0yzbHaNSOoi53I5CcJYNMG2yA==
-  dependencies:
-    "@comunica/bus-rdf-serialize" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    jsonld-streaming-serializer "^2.0.1"
-
-"@comunica/actor-rdf-serialize-jsonld@^2.6.6":
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.6.6.tgz#367d583cb9e51fb4205e55cbc63808d21d82125a"
-  integrity sha512-CPwmXj1HsdL+vYlBuQ3wI6Ozw+IKfN0Fq7T4N+Ch01GVxN55rLb31JaPjE2rs4OxXD33gf57YE6Z0UTuGvwh/g==
-  dependencies:
-    "@comunica/bus-rdf-serialize" "^2.6.0"
-    "@comunica/types" "^2.6.0"
-    jsonld-streaming-serializer "^2.0.1"
-
-"@comunica/actor-rdf-serialize-jsonld@^2.8.2":
+"@comunica/actor-rdf-serialize-jsonld@^2.6.6", "@comunica/actor-rdf-serialize-jsonld@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.8.2.tgz#111c8e90c37066561042684bb12f10cf948b8203"
   integrity sha512-PChSSIqoRm7Kml565iiT735hcEdDDlNP9gjE00CSng8ByFf8chjl2E+6fQG0xiQS2Mfi2QgD6tLCEK9+O18PHw==
@@ -1805,25 +1641,7 @@
     "@comunica/types" "^2.8.2"
     jsonld-streaming-serializer "^2.1.0"
 
-"@comunica/actor-rdf-serialize-n3@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.5.1.tgz#cde99b853d2ed51314b1d0b3fdfbb8a20e71c0f2"
-  integrity sha512-llK3kiNtqrEBTL5z8GIDM/SjT9nv41Pugm+H/j+hTjNIVfSCHpaobUuQdft7TDVYeXu6/U18lXcz8n1bAspKfA==
-  dependencies:
-    "@comunica/bus-rdf-serialize" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    n3 "^1.16.3"
-
-"@comunica/actor-rdf-serialize-n3@^2.6.6":
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.6.6.tgz#4c42fffc70f1d8f6b70059fcb46b8801db78ef6a"
-  integrity sha512-K9LYDPzqX38yXb4TImQlwXyx+KjR0F5fyGEiRfRK1MCGhVmATBl/VECvWkYNG7oNh2Li4HAM5g3b6u3VsCCczw==
-  dependencies:
-    "@comunica/bus-rdf-serialize" "^2.6.0"
-    "@comunica/types" "^2.6.0"
-    n3 "^1.16.3"
-
-"@comunica/actor-rdf-serialize-n3@^2.8.2":
+"@comunica/actor-rdf-serialize-n3@^2.6.6", "@comunica/actor-rdf-serialize-n3@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.8.2.tgz#91c3af69220ae3ab4e04fd9957a80b03425a9f7c"
   integrity sha512-ZlHdt6DpE5oRU13tlAlO7R14mwP/zGlooSSniUmbuh0vO1t8CjPe7iD1V8kj1KDH7E+aadIp50uc+nirGJKeQA==
@@ -1832,18 +1650,7 @@
     "@comunica/types" "^2.8.2"
     n3 "^1.17.0"
 
-"@comunica/actor-rdf-serialize-shaclc@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.6.0.tgz#944c01e9bd04c0e6e74e7702c370d905cd4aa2dc"
-  integrity sha512-ysa57SuaEDsQO+A+fV3bdTTPI2+tdO4xQ5QqXWmZ0SVoBeakBQJq78mnk9KngGOApe0fclxxri/koAMSILAarQ==
-  dependencies:
-    "@comunica/bus-rdf-serialize" "^2.6.0"
-    "@comunica/types" "^2.6.0"
-    arrayify-stream "^2.0.1"
-    readable-stream "^4.3.0"
-    shaclc-write "^1.4.2"
-
-"@comunica/actor-rdf-serialize-shaclc@^2.8.2":
+"@comunica/actor-rdf-serialize-shaclc@^2.6.0", "@comunica/actor-rdf-serialize-shaclc@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.8.2.tgz#1e83a447e9aaae820e7ba0b5870591e41991d6f2"
   integrity sha512-rySVO0zN9S3B3CjKpbCU/yyIxD+QroaJ509iBbHmriGeV8HfefE427ZpwKjObrd6m3VVLdtyZz2dVW+bUMChXg==
@@ -1930,17 +1737,7 @@
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
 
-"@comunica/bindings-factory@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bindings-factory/-/bindings-factory-2.5.1.tgz#18fc7269dc8d11f8de28b8c8c21c80ea80464250"
-  integrity sha512-w8L9t17EaBibuyDXQAjSK04E4E3s/WWsSCNQz7QzG8dpLqscLfwiE0OBJpqpqGZ8pBkgQPt/JyC2WAqwPi5CHg==
-  dependencies:
-    "@rdfjs/types" "*"
-    immutable "^4.1.0"
-    rdf-data-factory "^1.1.1"
-    rdf-string "^1.6.1"
-
-"@comunica/bindings-factory@^2.7.0":
+"@comunica/bindings-factory@^2.0.1", "@comunica/bindings-factory@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@comunica/bindings-factory/-/bindings-factory-2.7.0.tgz#b35810178beed08803ba1891faf50bcd017f52c8"
   integrity sha512-NeLbBmqiNhyUCZSfqZfwZD50dQ5+DABgPbzfuZnbHq9uSfhxAzuGCzgrK0hmuwRHWOPBtmeRnyZTJorePuxTzQ==
@@ -1958,17 +1755,7 @@
     "@comunica/core" "^2.8.2"
     "@comunica/types" "^2.8.2"
 
-"@comunica/bus-dereference-rdf@^2.0.2":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.5.1.tgz#889da41ddf6b31cb8bd6c4440eab6601522f6ff7"
-  integrity sha512-QdATU52U4wpC2OILe0p9twbHbl9LjhyeTYblcc4FaGEjgJ/8TqiWpwIzZEnCPRdE+yOy9QNXLjna5/B7hVNHsw==
-  dependencies:
-    "@comunica/bus-dereference" "^2.5.1"
-    "@comunica/bus-rdf-parse" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@rdfjs/types" "*"
-
-"@comunica/bus-dereference-rdf@^2.8.2":
+"@comunica/bus-dereference-rdf@^2.0.2", "@comunica/bus-dereference-rdf@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.8.2.tgz#3af17791b6c70447f6f45c26d9b5c35a4f83d152"
   integrity sha512-Q/4oM6AsVi2kr9e040kZtOaeHeFao8zeV8VUgC8WceATkT6FVK/+STzOFabny1yQHSIKC54kj24pfvXJftEYhQ==
@@ -1978,19 +1765,7 @@
     "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-dereference@^2.0.2", "@comunica/bus-dereference@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference/-/bus-dereference-2.5.1.tgz#84512109e33d474349f1d7731eddc9457c8ea5ec"
-  integrity sha512-KQTc5ZfY6bqJSQov9QYiq2mFxuTDgnN+4mzHNcyqODrIf2UYefBV453uX+nZv9cE1hdUHP8+qJiNLjO/L1y3wA==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^2.5.1"
-    "@comunica/actor-abstract-parse" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    readable-stream "^4.2.0"
-
-"@comunica/bus-dereference@^2.8.2":
+"@comunica/bus-dereference@^2.0.2", "@comunica/bus-dereference@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/bus-dereference/-/bus-dereference-2.8.2.tgz#3adacaac3fed627c721a0e49daa469746dbb781c"
   integrity sha512-bg4A6fdkNv1CZkBJ33JvG3Xb6zloq7ElwtVMEBytzeuQV4/UuOrF8MYe9s6my+qRb3v4gDw9UYgIfePIDZMEsA==
@@ -2017,18 +1792,7 @@
   dependencies:
     "@comunica/core" "^2.8.2"
 
-"@comunica/bus-http@^2.0.1", "@comunica/bus-http@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-http/-/bus-http-2.5.1.tgz#2d94d83d067b4b66d9752df5886a4d5391019100"
-  integrity sha512-kouDqVoP6qAVQ4pflMmedBHfMtuLoBgqwX3mHdlUtrE0h1I+/EX6M5eUe5pXI6PfJrn3cInHyu+UZkbZYrykAw==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-    is-stream "^2.0.1"
-    readable-stream-node-to-web "^1.0.1"
-    readable-web-to-node-stream "^3.0.2"
-    web-streams-ponyfill "^1.4.2"
-
-"@comunica/bus-http@^2.8.2":
+"@comunica/bus-http@^2.0.1", "@comunica/bus-http@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/bus-http/-/bus-http-2.8.2.tgz#b51b237383db1bda2b0f0315d84ecb53cc0981d3"
   integrity sha512-Seh7NXgTCuXbExJYgMKQDNSl8tdxaQWg5GtNiZAePE0aUwaosa2SsLifex1DJN7P1dW2OAaGzZhTB6+v9dKX4Q==
@@ -2039,15 +1803,7 @@
     readable-web-to-node-stream "^3.0.2"
     web-streams-ponyfill "^1.4.2"
 
-"@comunica/bus-init@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-2.5.1.tgz#511b21a95f0af07a6914d442045a00bb65281e23"
-  integrity sha512-TDakSkGzM+3xkZ+xBCBmzWNagmDWUc+F6TPYOFO8goaT1+tVrPh9wPD5t2n1zkKMzG2dOVT4O8jxUfCyzmNwKA==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-    readable-stream "^4.2.0"
-
-"@comunica/bus-init@^2.8.2":
+"@comunica/bus-init@^2.0.1", "@comunica/bus-init@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-2.8.2.tgz#8fb8225531de05b55008b5ac470dfd204ce00b3e"
   integrity sha512-KvRHO0j7Z4YS1Czxm985US7/fa7aL8jUlmS1AyJnw9jcl1+gYhtDRbopyJ4DGBgfV1fxve+UFXs7gpROrrh3Ow==
@@ -2155,15 +1911,7 @@
     "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-parse-html@^2.0.1", "@comunica/bus-rdf-parse-html@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.5.1.tgz#8b6f52505525e6d650a328839d7d75056b929d60"
-  integrity sha512-+YZiAbA2h82/+FGDJPjqHdfq6l0dm3W11V0jHcOaAsk+AK2JvvoouYdFAGshhroxQwv5WPsXbtzy6XJmVtZ4MQ==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-    "@rdfjs/types" "*"
-
-"@comunica/bus-rdf-parse-html@^2.8.2":
+"@comunica/bus-rdf-parse-html@^2.0.1", "@comunica/bus-rdf-parse-html@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.8.2.tgz#a2e07b39ea64b0759b61a7f33a6787d8c8e5fb43"
   integrity sha512-r20sl/NPC2YJCPFfWUCSYVZzYhoKK1ZJ0UJ8HubKte8EURG3TqUb9hQKSMcq9GbqSASR/lPUwSLL4VuKKD3aTw==
@@ -2171,17 +1919,7 @@
     "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-parse@^2.0.1", "@comunica/bus-rdf-parse@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.5.1.tgz#f69c0ce68e61cb064274a47eaa8803c80b40ba57"
-  integrity sha512-BzfvedLkh1bOSa/WeUzLc/bQlcXWKhIkG/GwIOrCFtoWJOdOlapWdPvPS5U6sEW/UW454ClRWaqIA+GM0qeyzA==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^2.5.1"
-    "@comunica/actor-abstract-parse" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@rdfjs/types" "*"
-
-"@comunica/bus-rdf-parse@^2.8.2":
+"@comunica/bus-rdf-parse@^2.0.1", "@comunica/bus-rdf-parse@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.8.2.tgz#cec32710484186e103fbba1e958fd59fc513538a"
   integrity sha512-XimvJuWJGuolpUs4w+im4fw8Lc8jPj6gKM/2fE/cenWO/m6RafnvcOqjMs80toueuoFRaF/TIxOY09t6G+p0VA==
@@ -2229,25 +1967,7 @@
     asynciterator "^3.8.1"
     sparqlalgebrajs "^4.2.0"
 
-"@comunica/bus-rdf-serialize@^2.0.1", "@comunica/bus-rdf-serialize@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.5.1.tgz#a9ed10659f8a95d93b054b845a3f5a87589629cd"
-  integrity sha512-GMg3dkWrFSYzxsp8hDNSgpWKyInDQ78lmy9TqVUo+EIgvIDhMXZJqsJmQNf/frcMYlPqdr1CwGnRxp+Jf7li+g==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@rdfjs/types" "*"
-
-"@comunica/bus-rdf-serialize@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.6.0.tgz#3b6b27bcb7bfac831da737d7c11d75bc177dfa12"
-  integrity sha512-WeTMUNBztxeMZ8BYf9xbvXzvLircPXgx90MZerisW5L5INzvPw1CnTCnnAYBfCxBafsN9OQGIOphhIb5rYY0iA==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^2.6.0"
-    "@comunica/core" "^2.6.0"
-    "@rdfjs/types" "*"
-
-"@comunica/bus-rdf-serialize@^2.8.2":
+"@comunica/bus-rdf-serialize@^2.0.1", "@comunica/bus-rdf-serialize@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.8.2.tgz#77660f0c66a935f926fd0633389a726255eb940d"
   integrity sha512-HAmDo3p1uw7WM/oUERa+1/UKcoATIHk6DCJgzXBWocwniCLb7b2sHQJR/SteFyH0U01JIgIn7cYyQsFkmfewHg==
@@ -2278,26 +1998,10 @@
     asynciterator "^3.8.1"
     stream-to-string "^1.2.0"
 
-"@comunica/config-query-sparql@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-2.5.1.tgz#35a18f901fa34f60ca459486152a4bf07633bac6"
-  integrity sha512-Fg/PDp0BwoFcCBeVTPTDR8pgXjuuMXTLi3SJFT0GdgtwSPHlAikMHGywyOMK9I1TlZ2Fwwl/oIhZVNFY3Uz7YA==
-
-"@comunica/config-query-sparql@^2.7.0":
+"@comunica/config-query-sparql@^2.0.1", "@comunica/config-query-sparql@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz#1030ee76d5532bc6a09a6c8af26a06c7311a5861"
   integrity sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA==
-
-"@comunica/context-entries@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/context-entries/-/context-entries-2.5.1.tgz#f3df1155303fd6f280123cea4695c68f5411dd38"
-  integrity sha512-TnF476Nv9+DfZ+JLTQU7OSqmFREScVkpBtU71seT6He+vkJBHDm6Nq4tnKwDmAI3v9dCc5dgCRU4F2uPDjBKZA==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    "@rdfjs/types" "*"
-    jsonld-context-parser "^2.2.2"
-    sparqlalgebrajs "^4.0.5"
 
 "@comunica/context-entries@^2.6.8", "@comunica/context-entries@^2.8.1", "@comunica/context-entries@^2.8.2":
   version "2.8.2"
@@ -2310,23 +2014,7 @@
     jsonld-context-parser "^2.2.2"
     sparqlalgebrajs "^4.2.0"
 
-"@comunica/core@^2.0.1", "@comunica/core@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/core/-/core-2.5.1.tgz#9851ddd77e4baa4c989e7c8f90b4c63116bcbf50"
-  integrity sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==
-  dependencies:
-    "@comunica/types" "^2.5.1"
-    immutable "^4.1.0"
-
-"@comunica/core@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@comunica/core/-/core-2.6.0.tgz#70e4cec31a1122a148935d72de3ac9b8a34cdcd3"
-  integrity sha512-35M8q1JEf8jSjdc00FYT/aO+OS8cMSaJikGuIsk9ZDZNCNkXbmdqVr/VabNKV+V7CS1vciFORgRjeMklz5SIUA==
-  dependencies:
-    "@comunica/types" "^2.6.0"
-    immutable "^4.1.0"
-
-"@comunica/core@^2.8.2":
+"@comunica/core@^2.0.1", "@comunica/core@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/core/-/core-2.8.2.tgz#ed1006d076ccd8f87180cc66e0b242a92c527815"
   integrity sha512-8UrhEilUDxRTltFCI4uxz3nch02lGK1KFHBUCUxp/9EmnnQUYvwbMCMS6sLxYHTqJ18/SMFFEwgBMsTX/N+wuA==
@@ -2364,15 +2052,7 @@
   dependencies:
     "@comunica/core" "^2.8.2"
 
-"@comunica/mediator-combine-pipeline@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.5.1.tgz#54e9a40ed28afdd3a44d71f6324d35bb426ab3ff"
-  integrity sha512-vsi6YA7NGPQoNSPtKHWUbsDK+678w0BdE9DEzLWOa2pqiWoeT4SuJV4szHQNVuJjzi6j6VTXuR58mZL7XqreTw==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-
-"@comunica/mediator-combine-pipeline@^2.8.2":
+"@comunica/mediator-combine-pipeline@^2.0.1", "@comunica/mediator-combine-pipeline@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.8.2.tgz#09333ee9e69202ec34a37613229f999281beb138"
   integrity sha512-XjN3EWdKC2XDY6gr1po5GttsRuM1FewzW3KRlLoYkRzH0+S3Th5Ef6zTlgDef4tWqVgNXIzC5Ccz0HraKKEbdg==
@@ -2380,14 +2060,7 @@
     "@comunica/core" "^2.8.2"
     "@comunica/types" "^2.8.2"
 
-"@comunica/mediator-combine-union@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-2.5.1.tgz#18fb5fcd8ea091089306fd9cb4ebb4d9e2a04720"
-  integrity sha512-vpbQn3xtoX+F00xv+AKbn+qUe66rIiycbiZoE/s/qtlmUbVKLItEMMuToDGRdcdC9mtPiieIrgremXd/RVdHTw==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-
-"@comunica/mediator-combine-union@^2.8.2":
+"@comunica/mediator-combine-union@^2.0.1", "@comunica/mediator-combine-union@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-2.8.2.tgz#71be8ca6050443a49cdbaf273434895d2c780168"
   integrity sha512-TjSHJdtbdiV96m+GaPUT+44Q4SOG8dcESO3YuJhRklAf6oOYfXL9d+7ITixSo7tiZQSv1LlgxG1apzBDTM1BvA==
@@ -2405,28 +2078,14 @@
     "@comunica/mediatortype-join-coefficients" "^2.8.2"
     "@comunica/types" "^2.8.2"
 
-"@comunica/mediator-number@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-2.5.1.tgz#77579f4a2ade4f5c292448ab8434cb8993ffcc60"
-  integrity sha512-pOTtj5WJEh8gNlNesxe7YG90J2dQobp8ulkzP/bzsd/DC14OOxYlcTke/c+GqZH6SaatUmz/R7Za5AWdipqYcw==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-
-"@comunica/mediator-number@^2.8.2":
+"@comunica/mediator-number@^2.0.1", "@comunica/mediator-number@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-2.8.2.tgz#447f7951db02e24755b3dc477bf0326bbc5f12ad"
   integrity sha512-7VP1bMUusiG7AecQxrPfSunK408+oW4kdNNjavEJ7+pLi/95bT/e/rq/0wbK9Wu0vVrn7JNbliekLdhdI/BIuA==
   dependencies:
     "@comunica/core" "^2.8.2"
 
-"@comunica/mediator-race@^2.0.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-2.5.1.tgz#6c8e3c906fc2c3215a4af5a719a5b6b5a78ca607"
-  integrity sha512-VuHHZSDagK9k85NBTEvbbhkb/Xd9zgt9jBlYIVRarushJ8ihqfs8dXQ2Hs0gdOTyrCMFiQIimbN1h58QcmmKyg==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-
-"@comunica/mediator-race@^2.8.2":
+"@comunica/mediator-race@^2.0.1", "@comunica/mediator-race@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-2.8.2.tgz#d77507aca27170599943c2bb1c39aeaa14134831"
   integrity sha512-oD9bw8YLV8TTedFBigPuqWKNxu64uLwsfve0OYV2J0tZHPTiYp8XJoeWN1mxc0q4TimxqXfKn4gXD5MP06MUsQ==
@@ -2454,13 +2113,6 @@
   dependencies:
     "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
-
-"@comunica/mediatortype-time@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-time/-/mediatortype-time-2.5.1.tgz#0277b449db7ecee88d46bebfcce2d749f3636b68"
-  integrity sha512-3xaRx+MzUtKd8LXJcMOB2VwuH9FrgODStUaVbkcAwBoPLxFJzYvgtv49iF/e8X3vY1u0EYzJMQXjuA3sV5niRw==
-  dependencies:
-    "@comunica/core" "^2.5.1"
 
 "@comunica/mediatortype-time@^2.8.2":
   version "2.8.2"
@@ -2634,26 +2286,6 @@
     componentsjs "^5.3.2"
     process "^0.11.10"
 
-"@comunica/types@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/types/-/types-2.5.1.tgz#eda48301fc2ce783a3a58584954bb1de88a688ac"
-  integrity sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@types/yargs" "^17.0.13"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/types@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@comunica/types/-/types-2.6.0.tgz#27e6f505fb578fa2dabdc964fa762051c67b168a"
-  integrity sha512-YC+59WpGV4lu8Qe7olXXPAToERIMCH2NnkFCnIUoM4BWO0LKs0Hr8PXUb+Aslc7puLipuCgDcw+zVSIjAm4/CQ==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@types/yargs" "^17.0.13"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
-
 "@comunica/types@^2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@comunica/types/-/types-2.8.2.tgz#b910c1ed767118958184e47432c9cc47e9c4c884"
@@ -2672,6 +2304,18 @@
     colorspace "1.1.x"
     enabled "2.0.x"
     kuler "^2.0.0"
+
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.8.0.tgz#11195513186f68d42fbf449f9a7136b2c0c92005"
+  integrity sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -2711,6 +2355,18 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
   integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -2944,45 +2600,37 @@
   optionalDependencies:
     fsevents "^2.3.2"
 
-"@jridgewell/gen-mapping@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
-  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
-  dependencies:
-    "@jridgewell/set-array" "^1.0.0"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
-"@jridgewell/gen-mapping@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
-  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
+  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
   dependencies:
     "@jridgewell/set-array" "^1.0.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
-"@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
+"@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
-  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
+"@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz#f8a3249862f91be48d3127c3cfe992f79b4b8811"
+  integrity sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==
   dependencies:
-    "@jridgewell/resolve-uri" "3.1.0"
-    "@jridgewell/sourcemap-codec" "1.4.14"
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@koa/cors@^3.1.0":
   version "3.4.3"
@@ -3034,6 +2682,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
 "@rdfjs/data-model@^1.1.0", "@rdfjs/data-model@^1.2.0":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@rdfjs/data-model/-/data-model-1.3.4.tgz#2b1b3e52755ab1283bf66aa2d3ac97fd8a0332c2"
@@ -3074,24 +2727,24 @@
   dependencies:
     "@types/node" "*"
 
-"@rubensworks/eslint-config@^1.0.1":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@rubensworks/eslint-config/-/eslint-config-1.1.0.tgz#752cf99b75e2835c239afc4136b47a356f8ffd4d"
-  integrity sha512-ZAPifXpRLeIvsOMkJT3U9YKnKXBy0qrHovRPRdXG2nngMcl3zIMDVZZTPNu8CDONA4rsbAYbJvzXdLDJPi8daA==
+"@rubensworks/eslint-config@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@rubensworks/eslint-config/-/eslint-config-2.0.0.tgz#9f8ec8634a0246a385585f8536b9c3fbcd3ad759"
+  integrity sha512-SjFaqcvje0AuZvMTMJnq6XAiN1g4W2zMIGLeteUNr2aUlEsjvq7hiF54L2+qJWMa8SXPaBIoCjRsZ73G9GIFuw==
   dependencies:
     "@rushstack/eslint-patch" "^1.2.0"
-    "@typescript-eslint/eslint-plugin" "^5.11.0"
-    "@typescript-eslint/parser" "^5.11.0"
-    eslint-config-es "4.1.0"
-    eslint-import-resolver-typescript "^2.5.0"
+    "@typescript-eslint/eslint-plugin" "^5.43.0"
+    "@typescript-eslint/parser" "^5.43.0"
+    eslint-config-es "4.2.0"
+    eslint-import-resolver-typescript "^2.7.1"
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-extended "0.2.0"
-    eslint-plugin-import "2.25.4"
+    eslint-plugin-import "2.26.0"
     eslint-plugin-jest "^26.0.0"
     eslint-plugin-mocha "9.0.0"
-    eslint-plugin-react "7.29.3"
-    eslint-plugin-react-hooks "4.3.0"
-    eslint-plugin-tsdoc "^0.2.14"
+    eslint-plugin-react "7.31.10"
+    eslint-plugin-react-hooks "4.6.0"
+    eslint-plugin-tsdoc "^0.2.17"
     eslint-plugin-unicorn "37.0.1"
     eslint-plugin-unused-imports "^2.0.0"
 
@@ -3103,9 +2756,9 @@
     xmlchars "^2.2.0"
 
 "@rushstack/eslint-patch@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
-  integrity sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.3.3.tgz#16ab6c727d8c2020a5b6e4a176a243ecd88d8d69"
+  integrity sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw==
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
@@ -3113,9 +2766,9 @@
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
 "@sinonjs/commons@^1.7.0":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.5.tgz#e280c94c95f206dcfd5aca00a43f2156b758c764"
-  integrity sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
+  integrity sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==
   dependencies:
     type-detect "4.0.8"
 
@@ -3233,23 +2886,18 @@
   dependencies:
     "@types/node" "*"
 
-"@types/async-lock@^1.1.2":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/async-lock/-/async-lock-1.3.0.tgz#12d165b890935afbc553eb9db467c0b540658b8e"
-  integrity sha512-Z93wDSYW9aMgPR5t+7ouwTvy91Vp3M0Snh4Pd3tf+caSAq5bXZaGnnH9CDbjrwgmfDkRIX0Dx8GvSDgwuoaxoA==
-
-"@types/async-lock@^1.4.0":
+"@types/async-lock@^1.1.2", "@types/async-lock@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/async-lock/-/async-lock-1.4.0.tgz#e7d555d037f93e911d54000acb626e783ff9023a"
   integrity sha512-2+rYSaWrpdbQG3SA0LmMT6YxWLrI81AqpMlSkw3QtFc2HGDufkweQSn30Eiev7x9LL0oyFrBqk1PXOnB9IEgKg==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
-  version "7.1.20"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.20.tgz#e168cdd612c92a2d335029ed62ac94c95b362359"
-  integrity sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.1.tgz#916ecea274b0c776fec721e333e55762d3a9614b"
+  integrity sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==
   dependencies:
-    "@babel/parser" "^7.1.0"
-    "@babel/types" "^7.0.0"
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
     "@types/babel__generator" "*"
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
@@ -3270,16 +2918,16 @@
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
-  version "7.18.2"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.18.2.tgz#235bf339d17185bdec25e024ca19cce257cc7309"
-  integrity sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.20.1.tgz#dd6f1d2411ae677dcb2db008c962598be31d6acf"
+  integrity sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==
   dependencies:
-    "@babel/types" "^7.3.0"
+    "@babel/types" "^7.20.7"
 
 "@types/bcryptjs@^2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.2.tgz#e3530eac9dd136bfdfb0e43df2c4c5ce1f77dfae"
-  integrity sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.3.tgz#2302ab44f10912579a183c96eb0e3b951c929915"
+  integrity sha512-XTnH9E/rp51aKGsiMtQCHV/owDLW2E9QAxI7ItpWWm6Gi6XO1e4o3VuEYDma0lbitj1vNOBj05Qk8l2BYoiN4A==
 
 "@types/body-parser@*":
   version "1.19.2"
@@ -3329,22 +2977,24 @@
     "@types/node" "*"
 
 "@types/cors@^2.8.12":
-  version "2.8.12"
-  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
-  integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
+  version "2.8.13"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.13.tgz#b8ade22ba455a1b8cb3b5d3f35910fd204f84f94"
+  integrity sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/docker-modem@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/docker-modem/-/docker-modem-3.0.2.tgz#c49c902e17364fc724e050db5c1d2b298c6379d4"
-  integrity sha512-qC7prjoEYR2QEe6SmCVfB1x3rfcQtUr1n4x89+3e0wSTMQ/KYCyf+/RAA9n2tllkkNc6//JMUZePdFRiGIWfaQ==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/docker-modem/-/docker-modem-3.0.3.tgz#28e1d4971fc88073bbd03c989b40c978af693def"
+  integrity sha512-i1A2Etnav7uHizZ87vUf4EqwJehY3JOcTfBS0pGBlO+HQ0jg2lUMCaJRg9VQM8ldZkpYdIfsenxcTOCpwxPXEg==
   dependencies:
     "@types/node" "*"
     "@types/ssh2" "*"
 
 "@types/dockerode@^3.2.3":
-  version "3.3.14"
-  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.14.tgz#0c4ff53ea9990c43d525c865525f13e084afb5b0"
-  integrity sha512-PUTwtySPzCbjZ/uqRMBWKHtLGqBAlhnLitzHuom19NEX0KBYsQXqbVlig+zbUgYQU1paDeQURXj7QNglh1RI6A==
+  version "3.3.19"
+  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.19.tgz#59eb07550a102b397a9504083a6c50d811eed04c"
+  integrity sha512-7CC5yIpQi+bHXwDK43b/deYXteP3Lem9gdocVVHJPSRJJLMfbiOchQV3rDmAPkMw+n3GIVj7m1six3JW+VcwwA==
   dependencies:
     "@types/docker-modem" "*"
     "@types/node" "*"
@@ -3361,22 +3011,23 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@^4.17.18":
-  version "4.17.31"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
-  integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
+"@types/express-serve-static-core@^4.17.33":
+  version "4.17.36"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz#baa9022119bdc05a4adfe740ffc97b5f9360e545"
+  integrity sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
+    "@types/send" "*"
 
 "@types/express@*":
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
-  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
+  version "4.17.17"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.17.tgz#01d5437f6ef9cfa8668e616e13c2f2ac9a491ae4"
+  integrity sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.18"
+    "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "*"
 
@@ -3396,9 +3047,9 @@
     "@types/node" "*"
 
 "@types/graceful-fs@^4.1.2":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
-  integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
+  integrity sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==
   dependencies:
     "@types/node" "*"
 
@@ -3459,10 +3110,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/json-schema@^7.0.3", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.9":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+"@types/json-schema@^7.0.9":
+  version "7.0.12"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -3496,9 +3147,9 @@
     "@types/koa" "*"
 
 "@types/koa@*":
-  version "2.13.5"
-  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.13.5.tgz#64b3ca4d54e08c0062e89ec666c9f45443b21a61"
-  integrity sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.13.8.tgz#4302d2f2712348aadb6c0b03eb614f30afde486b"
+  integrity sha512-Ugmxmgk/yPRW3ptBTh9VjOLwsKWJuGbymo1uGX0qdaqqL18uJiiG1ZoV0rxCOYSaDGhvEp5Ece02Amx0iwaxQQ==
   dependencies:
     "@types/accepts" "*"
     "@types/content-disposition" "*"
@@ -3517,9 +3168,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.190"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.190.tgz#d8e99647af141c63902d0ca53cf2b34d2df33545"
-  integrity sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==
+  version "4.14.197"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.197.tgz#e95c5ddcc814ec3e84c891910a01e0c8a378c54b"
+  integrity sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==
 
 "@types/lru-cache@^5.1.0", "@types/lru-cache@^5.1.1":
   version "5.1.1"
@@ -3548,6 +3199,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
@@ -3561,27 +3217,27 @@
     "@types/node" "*"
 
 "@types/n3@^1.10.4":
-  version "1.10.4"
-  resolved "https://registry.yarnpkg.com/@types/n3/-/n3-1.10.4.tgz#fd23d15fd7e47cf6d199d1f44ac5d6930cc50905"
-  integrity sha512-FfRTwcbXcScVHuAjIASveRWL6Fi6fPALl1Ge8tMESYLqU7R42LJvtdBpUi+f9YK0oQPqIN+zFFgMDFJfLMx0bg==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@types/n3/-/n3-1.16.0.tgz#6ab894bd2004cc5b6d1a8e09f27d39ceb157b377"
+  integrity sha512-g/67NVSihmIoIZT3/J462NhJrmpCw+5WUkkKqpCE9YxNEWzBwKavGPP+RUmG6DIm5GrW4GPunuxLJ0Yn/GgNjQ==
   dependencies:
+    "@rdfjs/types" "^1.1.0"
     "@types/node" "*"
-    rdf-js "^4.0.2"
 
-"@types/node@*", "@types/node@^18.0.0":
-  version "18.11.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
-  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
-"@types/node@^14.14.7":
-  version "14.18.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.33.tgz#8c29a0036771569662e4635790ffa9e057db379b"
-  integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
+"@types/node@*":
+  version "20.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.7.tgz#4b8ecac87fbefbc92f431d09c30e176fc0a7c377"
+  integrity sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==
 
 "@types/node@^14.18.43":
   version "14.18.56"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.56.tgz#09e092d684cd8cfbdb3c5e5802672712242f2600"
   integrity sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==
+
+"@types/node@^18.0.0", "@types/node@^18.11.18":
+  version "18.17.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.12.tgz#c6bd7413a13e6ad9cfb7e97dd5c4e904c1821e50"
+  integrity sha512-d6xjC9fJ/nSnfDeU0AMDsaJyb1iHsqCSOdi84w4u+SlN/UgQdY5tRhpMzaFYsI4mnpvgTivEaQd0yOUhAtOnEQ==
 
 "@types/nodemailer@^6.4.7":
   version "6.4.9"
@@ -3608,9 +3264,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^2.0.0":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
-  integrity sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
+  integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
 
 "@types/proper-lockfile@^4.1.2":
   version "4.1.2"
@@ -3670,15 +3326,24 @@
   integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
 
 "@types/semver@^7.3.12", "@types/semver@^7.3.4":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.1.tgz#0480eeb7221eb9bc398ad7432c9d7e14b1a5a367"
+  integrity sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==
+
+"@types/send@*":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.1.tgz#ed4932b8a2a805f1fe362a70f4e62d0ac994e301"
+  integrity sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
 
 "@types/serve-static@*":
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
-  integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.2.tgz#3e5419ecd1e40e7405d34093f10befb43f63381a"
+  integrity sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==
   dependencies:
+    "@types/http-errors" "*"
     "@types/mime" "*"
     "@types/node" "*"
 
@@ -3687,14 +3352,7 @@
   resolved "https://registry.yarnpkg.com/@types/spark-md5/-/spark-md5-3.0.2.tgz#da2e8a778a20335fc4f40b6471c4b0d86b70da55"
   integrity sha512-82E/lVRaqelV9qmRzzJ1PKTpyrpnT7mwdneKNJB9hUtypZDMggloDfFUCIqRRx3lYRxteCwXSq9c+W71Vf0QnQ==
 
-"@types/sparqljs@*", "@types/sparqljs@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@types/sparqljs/-/sparqljs-3.1.3.tgz#e4b9a2511bc2f14f564559ed6cf567835791a7e9"
-  integrity sha512-nmFgmR6ns4i8sg9fYu+293H+PMLKmDOZy34sgwgAeUEEiIqSs4guj5aCZRt3gq1g0yuKXkqrxLDq/684g7pGtQ==
-  dependencies:
-    rdf-js "^4.0.2"
-
-"@types/sparqljs@^3.1.4":
+"@types/sparqljs@*", "@types/sparqljs@^3.1.3", "@types/sparqljs@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@types/sparqljs/-/sparqljs-3.1.4.tgz#1600733caaf07ad487792aadbc9b0574b05f6228"
   integrity sha512-0MvCTEfveYJDkI91olLcDf/F3wMMbsxwNxiNZeglt4tbIFULd9pRpcacj1MuA+acFDkTnPXS9L7OqZNn/W1MAg==
@@ -3702,11 +3360,11 @@
     rdf-js "^4.0.2"
 
 "@types/ssh2@*":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@types/ssh2/-/ssh2-1.11.6.tgz#c114d15a3cfd2ba2f7ef219a2020c44f0fb8a01b"
-  integrity sha512-8Mf6bhzYYBLEB/G6COux7DS/F5bCWwojv/qFo2yH/e4cLzAavJnxvFXrYW59iKfXdhG6OmzJcXDasgOb/s0rxw==
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/@types/ssh2/-/ssh2-1.11.13.tgz#e6224da936abec0541bf26aa826b1cc37ea70d69"
+  integrity sha512-08WbG68HvQ2YVi74n2iSUnYHYpUdFc/s2IsI0BHBdJwaqYJpWlVv9elL0tYShTv60yr0ObdxJR5NrCRiGJ/0CQ==
   dependencies:
-    "@types/node" "*"
+    "@types/node" "^18.11.18"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -3718,10 +3376,15 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/triple-beam@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.2.tgz#38ecb64f01aa0d02b7c8f4222d7c38af6316fef8"
+  integrity sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==
+
 "@types/unzipper@^0.10.5":
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/@types/unzipper/-/unzipper-0.10.5.tgz#36a963cf025162b4ac31642590cb4192971d633b"
-  integrity sha512-NrLJb29AdnBARpg9S/4ktfPEisbJ0AvaaAr3j7Q1tg8AgcEUsq2HqbNzvgLRoWyRtjzeLEv7vuL39u1mrNIyNA==
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/@types/unzipper/-/unzipper-0.10.6.tgz#767101c65fa3968a725c02de11884f75952b091e"
+  integrity sha512-zcBj329AHgKLQyz209N/S9R0GZqXSkUQO4tJSYE3x02qg4JuDFpgKMj50r82Erk1natCWQDIvSccDddt7jPzjA==
   dependencies:
     "@types/node" "*"
 
@@ -3765,287 +3428,108 @@
     "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
-  version "15.0.14"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
-  integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  version "15.0.15"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.15.tgz#e609a2b1ef9e05d90489c2f5f45bbfb2be092158"
+  integrity sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==
   dependencies:
     "@types/yargs-parser" "*"
 
 "@types/yargs@^16.0.1":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
-  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+  version "16.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.5.tgz#12cc86393985735a283e387936398c2f9e5f88e3"
+  integrity sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^17.0.13":
-  version "17.0.14"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.14.tgz#0943473052c24bd8cf2d1de25f1a710259327237"
-  integrity sha512-9Pj7abXoW1RSTcZaL2Hk6G2XyLMlp5ECdVC/Zf2p/KBjC3srijLGgRAXOBjtFrJoIrvxdTKyKDA14bEcbxBaWw==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-"@types/yargs@^17.0.24":
+"@types/yargs@^17.0.13", "@types/yargs@^17.0.24":
   version "17.0.24"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.24.tgz#b3ef8d50ad4aa6aecf6ddc97c580a00f5aa11902"
   integrity sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.2.0.tgz#2bdb247cc2e2afce7efbce09afb9a6f0a8a08434"
-  integrity sha512-qQwg7sqYkBF4CIQSyRQyqsYvP+g/J0To9ZPVNJpfxfekl5RmdvQnFFTVVwpRtaUDFNvjfe/34TgY/dpc3MgNTw==
+"@typescript-eslint/eslint-plugin@^5.43.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
+  integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
   dependencies:
-    "@typescript-eslint/experimental-utils" "5.2.0"
-    "@typescript-eslint/scope-manager" "5.2.0"
-    debug "^4.3.2"
-    functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
-    regexpp "^3.2.0"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/eslint-plugin@^2.3.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/eslint-plugin@^4.2.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
-  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "4.33.0"
-    "@typescript-eslint/scope-manager" "4.33.0"
-    debug "^4.3.1"
-    functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
-    regexpp "^3.1.0"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/eslint-plugin@^5.11.0":
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.44.0.tgz#105788f299050c917eb85c4d9fd04b089e3740de"
-  integrity sha512-j5ULd7FmmekcyWeArx+i8x7sdRHzAtXTkmDPthE4amxZOWKFK7bomoJ4r7PJ8K7PoMzD16U8MmuZFAonr1ERvw==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.44.0"
-    "@typescript-eslint/type-utils" "5.44.0"
-    "@typescript-eslint/utils" "5.44.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/type-utils" "5.62.0"
+    "@typescript-eslint/utils" "5.62.0"
     debug "^4.3.4"
+    graphemer "^1.4.0"
     ignore "^5.2.0"
     natural-compare-lite "^1.4.0"
-    regexpp "^3.2.0"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
+"@typescript-eslint/parser@^5.43.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
+  integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/experimental-utils@4.33.0", "@typescript-eslint/experimental-utils@^4.0.1":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
-  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
-  dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-
-"@typescript-eslint/experimental-utils@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.2.0.tgz#e3b2cb9cd0aff9b50f68d9a414c299fd26b067e6"
-  integrity sha512-fWyT3Agf7n7HuZZRpvUYdFYbPk3iDCq6fgu3ulia4c7yxmPnwVBovdSOX7RL+k8u6hLbrXcdAehlWUVpGh6IEw==
-  dependencies:
-    "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.2.0"
-    "@typescript-eslint/types" "5.2.0"
-    "@typescript-eslint/typescript-estree" "5.2.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-
-"@typescript-eslint/parser@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.2.0.tgz#dc081aa89de16b5676b10215519af3aa7b58fb72"
-  integrity sha512-Uyy4TjJBlh3NuA8/4yIQptyJb95Qz5PX//6p8n7zG0QnN4o3NF9Je3JHbVU7fxf5ncSXTmnvMtd/LDQWDk0YqA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.2.0"
-    "@typescript-eslint/types" "5.2.0"
-    "@typescript-eslint/typescript-estree" "5.2.0"
-    debug "^4.3.2"
-
-"@typescript-eslint/parser@^4.1.1":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
-  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
-    debug "^4.3.1"
-
-"@typescript-eslint/parser@^5.11.0":
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.44.0.tgz#99e2c710a2252191e7a79113264f438338b846ad"
-  integrity sha512-H7LCqbZnKqkkgQHaKLGC6KUjt3pjJDx8ETDqmwncyb6PuoigYajyAwBGz08VU/l86dZWZgI4zm5k2VaKqayYyA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.44.0"
-    "@typescript-eslint/types" "5.44.0"
-    "@typescript-eslint/typescript-estree" "5.44.0"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
-  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
+"@typescript-eslint/scope-manager@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz#d9457ccc6a0b8d6b37d0eb252a23022478c5460c"
+  integrity sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==
   dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/visitor-keys" "4.33.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
 
-"@typescript-eslint/scope-manager@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.2.0.tgz#7ce8e4ab2baaa0ad5282913ea8e13ce03ec6a12a"
-  integrity sha512-RW+wowZqPzQw8MUFltfKYZfKXqA2qgyi6oi/31J1zfXJRpOn6tCaZtd9b5u9ubnDG2n/EMvQLeZrsLNPpaUiFQ==
+"@typescript-eslint/type-utils@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz#286f0389c41681376cdad96b309cedd17d70346a"
+  integrity sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==
   dependencies:
-    "@typescript-eslint/types" "5.2.0"
-    "@typescript-eslint/visitor-keys" "5.2.0"
-
-"@typescript-eslint/scope-manager@5.44.0":
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.44.0.tgz#988c3f34b45b3474eb9ff0674c18309dedfc3e04"
-  integrity sha512-2pKml57KusI0LAhgLKae9kwWeITZ7IsZs77YxyNyIVOwQ1kToyXRaJLl+uDEXzMN5hnobKUOo2gKntK9H1YL8g==
-  dependencies:
-    "@typescript-eslint/types" "5.44.0"
-    "@typescript-eslint/visitor-keys" "5.44.0"
-
-"@typescript-eslint/type-utils@5.44.0":
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.44.0.tgz#bc5a6e8a0269850714a870c9268c038150dfb3c7"
-  integrity sha512-A1u0Yo5wZxkXPQ7/noGkRhV4J9opcymcr31XQtOzcc5nO/IHN2E2TPMECKWYpM3e6olWEM63fq/BaL1wEYnt/w==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "5.44.0"
-    "@typescript-eslint/utils" "5.44.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
+    "@typescript-eslint/utils" "5.62.0"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
-  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+"@typescript-eslint/types@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
+  integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
 
-"@typescript-eslint/types@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.2.0.tgz#7ad32d15abddb0ee968a330f0ea182ea544ef7cf"
-  integrity sha512-cTk6x08qqosps6sPyP2j7NxyFPlCNsJwSDasqPNjEQ8JMD5xxj2NHxcLin5AJQ8pAVwpQ8BMI3bTxR0zxmK9qQ==
-
-"@typescript-eslint/types@5.44.0":
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.44.0.tgz#f3f0b89aaff78f097a2927fe5688c07e786a0241"
-  integrity sha512-Tp+zDnHmGk4qKR1l+Y1rBvpjpm5tGXX339eAlRBDg+kgZkz9Bw+pqi4dyseOZMsGuSH69fYfPJCBKBrbPCxYFQ==
-
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
+"@typescript-eslint/typescript-estree@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz#7d17794b77fabcac615d6a48fb143330d962eb9b"
+  integrity sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==
   dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/typescript-estree@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
-  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
-  dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/visitor-keys" "4.33.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/typescript-estree@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.2.0.tgz#c22e0ff6f8a4a3f78504a80ebd686fe2870a68ae"
-  integrity sha512-RsdXq2XmVgKbm9nLsE3mjNUM7BTr/K4DYR9WfFVMUuozHWtH5gMpiNZmtrMG8GR385EOSQ3kC9HiEMJWimxd/g==
-  dependencies:
-    "@typescript-eslint/types" "5.2.0"
-    "@typescript-eslint/visitor-keys" "5.2.0"
-    debug "^4.3.2"
-    globby "^11.0.4"
-    is-glob "^4.0.3"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/typescript-estree@5.44.0":
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.44.0.tgz#0461b386203e8d383bb1268b1ed1da9bc905b045"
-  integrity sha512-M6Jr+RM7M5zeRj2maSfsZK2660HKAJawv4Ud0xT+yauyvgrsHu276VtXlKDFnEmhG+nVEd0fYZNXGoAgxwDWJw==
-  dependencies:
-    "@typescript-eslint/types" "5.44.0"
-    "@typescript-eslint/visitor-keys" "5.44.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.44.0", "@typescript-eslint/utils@^5.10.0":
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.44.0.tgz#d733da4d79d6c30f1a68b531cdda1e0c1f00d52d"
-  integrity sha512-fMzA8LLQ189gaBjS0MZszw5HBdZgVwxVFShCO3QN+ws3GlPkcy9YuS3U4wkT6su0w+Byjq3mS3uamy9HE4Yfjw==
+"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
+  integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
   dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.44.0"
-    "@typescript-eslint/types" "5.44.0"
-    "@typescript-eslint/typescript-estree" "5.44.0"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
     eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
-  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
+"@typescript-eslint/visitor-keys@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz#2174011917ce582875954ffe2f6912d5931e353e"
+  integrity sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==
   dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    eslint-visitor-keys "^2.0.0"
-
-"@typescript-eslint/visitor-keys@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.2.0.tgz#03522d35df98474f08e0357171a7d1b259a88f55"
-  integrity sha512-Nk7HizaXWWCUBfLA/rPNKMzXzWS8Wg9qHMuGtT+v2/YpPij4nVXrVJc24N/r5WrrmqK31jCrZxeHqIgqRzs0Xg==
-  dependencies:
-    "@typescript-eslint/types" "5.2.0"
-    eslint-visitor-keys "^3.0.0"
-
-"@typescript-eslint/visitor-keys@5.44.0":
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.44.0.tgz#10740dc28902bb903d12ee3a005cc3a70207d433"
-  integrity sha512-a48tLG8/4m62gPFbJ27FxwCOqPKxsb8KC3HkmYoq2As/4YyjQl1jDbRr1s63+g4FS/iIehjmN3L5UjmKva1HzQ==
-  dependencies:
-    "@typescript-eslint/types" "5.44.0"
+    "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
 abab@^2.0.3, abab@^2.0.5:
@@ -4076,7 +3560,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.2.0, acorn-jsx@^5.3.1:
+acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -4092,9 +3576,9 @@ acorn@^7.1.1, acorn@^7.4.0:
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.2.4:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
-  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 agent-base@6:
   version "6.0.2"
@@ -4103,7 +3587,7 @@ agent-base@6:
   dependencies:
     debug "4"
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@~6.12.6:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@~6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -4140,7 +3624,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
   integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
   integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
@@ -4149,6 +3633,11 @@ ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -4163,6 +3652,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -4202,7 +3696,15 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
 
-array-includes@^3.1.3, array-includes@^3.1.4, array-includes@^3.1.5:
+array-buffer-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
+  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+  dependencies:
+    call-bind "^1.0.2"
+    is-array-buffer "^3.0.1"
+
+array-includes@^3.1.4, array-includes@^3.1.5, array-includes@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
   integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
@@ -4223,7 +3725,7 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==
 
-array.prototype.flat@^1.2.5:
+array.prototype.flat@^1.2.5, array.prototype.flat@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz#ffc6576a7ca3efc2f46a143b9d1dda9b4b3cf5e2"
   integrity sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==
@@ -4233,7 +3735,7 @@ array.prototype.flat@^1.2.5:
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
-array.prototype.flatmap@^1.2.4, array.prototype.flatmap@^1.2.5:
+array.prototype.flatmap@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz#1aae7903c2100433cb8261cd4ed310aab5c4a183"
   integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
@@ -4242,6 +3744,18 @@ array.prototype.flatmap@^1.2.4, array.prototype.flatmap@^1.2.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
+
+arraybuffer.prototype.slice@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz#9b5ea3868a6eebc30273da577eb888381c0044bb"
+  integrity sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    get-intrinsic "^1.2.1"
+    is-array-buffer "^3.0.2"
+    is-shared-array-buffer "^1.0.2"
 
 arrayify-stream@^1.0.0:
   version "1.0.0"
@@ -4258,7 +3772,7 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
 
-asn1@^0.2.4, asn1@~0.2.3:
+asn1@^0.2.6, asn1@~0.2.3:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
   integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
@@ -4275,11 +3789,6 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==
 
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -4295,20 +3804,15 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
-asynciterator@^3.6.0, asynciterator@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/asynciterator/-/asynciterator-3.8.0.tgz#d9246a3d39ce2a9e4b020834d7f352adf35b49d8"
-  integrity sha512-bD34LqKHJnkB77MHjL3hOAUOcy9dbB+3lHvL+EiJpD3k2Nyq3i1dCk5adMisB2rwlrHVu/+XRhOdPZL9hzpsfw==
-
-asynciterator@^3.8.1:
+asynciterator@^3.6.0, asynciterator@^3.8.0, asynciterator@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/asynciterator/-/asynciterator-3.8.1.tgz#80be735b252332494e186ee733544e5b21dd2123"
   integrity sha512-SmdG0FUY3pYGOZZGdYq8Qb/DCRDXBFZUk08V1/4lbBXdAQvcC3Kxzz9FUDPBTik7VAVltt4cZirAPtJv3gOpEw==
 
 asyncjoin@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/asyncjoin/-/asyncjoin-1.1.1.tgz#4a5c6a25381914dcecd380bf9c89aafabbf06370"
-  integrity sha512-8IqFEIQ3HVec3dLQBvLRx/EFDOof8o+r4nCahRGqGE6WDPTXk7IBEaL6clPZ87DHku7u4yxHGzGWqMN08YwErg==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/asyncjoin/-/asyncjoin-1.1.2.tgz#f630217394865b8d52d06e88ca91bec1f912a466"
+  integrity sha512-zi6B+C3GgEu8qrmFn3gDd58cbGNaNFW3s8DJmCxUOjQwqWZcQO6dEoZBWl56+QGQyX0da0FRX1fsAyYB9LmwJA==
   dependencies:
     asynciterator "^3.6.0"
 
@@ -4327,15 +3831,20 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
 
 aws4@^1.8.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
-  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
+  integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -4439,9 +3948,9 @@ big-integer@^1.6.17:
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
 
 bignumber.js@^9.0.1:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
-  integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
 binary@~0.3.0:
   version "0.3.0"
@@ -4508,15 +4017,15 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.21.3:
-  version "4.21.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
-  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
+browserslist@^4.21.9:
+  version "4.21.10"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.10.tgz#dbbac576628c13d3b2231332cb2ec5a46e015bb0"
+  integrity sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==
   dependencies:
-    caniuse-lite "^1.0.30001400"
-    electron-to-chromium "^1.4.251"
-    node-releases "^2.0.6"
-    update-browserslist-db "^1.0.9"
+    caniuse-lite "^1.0.30001517"
+    electron-to-chromium "^1.4.477"
+    node-releases "^2.0.13"
+    update-browserslist-db "^1.0.11"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -4563,10 +4072,10 @@ buffers@~0.1.1:
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
   integrity sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==
 
-buildcheck@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/buildcheck/-/buildcheck-0.0.3.tgz#70451897a95d80f7807e68fc412eb2e7e35ff4d5"
-  integrity sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==
+buildcheck@~0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/buildcheck/-/buildcheck-0.0.6.tgz#89aa6e417cfd1e2196e3f8fe915eb709d2fe4238"
+  integrity sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==
 
 builtin-modules@^3.3.0:
   version "3.3.0"
@@ -4612,9 +4121,9 @@ cacheable-lookup@^6.0.1:
   integrity sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==
 
 cacheable-request@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
-  integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.4.tgz#7a33ebf08613178b403635be7b899d3e69bbe817"
+  integrity sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==
   dependencies:
     clone-response "^1.0.2"
     get-stream "^5.1.0"
@@ -4656,10 +4165,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001400:
-  version "1.0.30001434"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz#ec1ec1cfb0a93a34a0600d37903853030520a4e5"
-  integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
+caniuse-lite@^1.0.30001517:
+  version "1.0.30001524"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz#1e14bce4f43c41a7deaeb5ebfe86664fe8dadb80"
+  integrity sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==
 
 canonicalize@^1.0.1:
   version "1.0.8"
@@ -4690,7 +4199,7 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
+chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4699,7 +4208,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -4712,11 +4221,6 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chardet@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
-  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -4728,9 +4232,9 @@ ci-info@^2.0.0:
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 ci-info@^3.2.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.7.0.tgz#6d01b3696c59915b6ce057e4aa4adfc2fa25f5ef"
-  integrity sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
+  integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
 
 cjs-module-lexer@^0.6.0:
   version "0.6.0"
@@ -4753,18 +4257,6 @@ clean-regexp@^1.0.0:
   integrity sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==
   dependencies:
     escape-string-regexp "^1.0.5"
-
-cli-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
-  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
-  dependencies:
-    restore-cursor "^3.1.0"
-
-cli-width@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
-  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -4819,9 +4311,9 @@ co@^4.6.0:
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
 collect-v8-coverage@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
-  integrity sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz#c0b29bcd33bcd0779a1344c2136051e6afd3d9e9"
+  integrity sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -4897,18 +4389,18 @@ component-emitter@^1.2.1:
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 componentsjs@^5.0.1, componentsjs@^5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/componentsjs/-/componentsjs-5.3.2.tgz#0b95c85e4184406cc7913142d65136c9b9e3f2c1"
-  integrity sha512-wqXaHjrnT4UDQT8Eaou/Itd55OWE7wasBivPJ0qfSlRMi5zRAwp3+sEgGO7F5T7hs0rMsrGTnkWWcoSHmrM/8A==
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/componentsjs/-/componentsjs-5.4.2.tgz#a433ce02d2f17b9598aff313deda8f48f11c58a0"
+  integrity sha512-qIeXLozDkvubl6qtiovWsIBRqUP80w1ImTbilB6QE3OQgaEExI8pYZ9MkZ10QDFtdoKUryztlqp0AWs49t4puA==
   dependencies:
     "@rdfjs/types" "*"
     "@types/minimist" "^1.2.0"
-    "@types/node" "^14.14.7"
+    "@types/node" "^18.0.0"
     "@types/semver" "^7.3.4"
     jsonld-context-parser "^2.1.1"
     minimist "^1.2.0"
     rdf-data-factory "^1.1.0"
-    rdf-object "^1.13.1"
+    rdf-object "^1.14.0"
     rdf-parse "^2.0.0"
     rdf-quad "^1.5.0"
     rdf-string "^1.6.0"
@@ -4929,9 +4421,9 @@ content-disposition@~0.5.2:
     safe-buffer "5.2.1"
 
 content-type@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
@@ -4991,20 +4483,20 @@ coveralls@^3.0.0:
     minimist "^1.2.5"
     request "^2.88.2"
 
-cpu-features@~0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.4.tgz#0023475bb4f4c525869c162e4108099e35bf19d8"
-  integrity sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==
+cpu-features@~0.0.8:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.9.tgz#5226b92f0f1c63122b0a3eb84cb8335a4de499fc"
+  integrity sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==
   dependencies:
-    buildcheck "0.0.3"
-    nan "^2.15.0"
+    buildcheck "~0.0.6"
+    nan "^2.17.0"
 
 cross-fetch@^3.0.6, cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
   dependencies:
-    node-fetch "2.6.7"
+    node-fetch "^2.6.12"
 
 cross-fetch@^4.0.0:
   version "4.0.0"
@@ -5013,7 +4505,7 @@ cross-fetch@^4.0.0:
   dependencies:
     node-fetch "^2.6.12"
 
-cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -5078,7 +4570,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -5113,14 +4605,14 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
 decimal.js@^10.2.1:
-  version "10.4.2"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
-  integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
+  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 decompress-response@^6.0.0:
   version "6.0.0"
@@ -5134,25 +4626,25 @@ deep-equal@~1.0.1:
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==
 
-deep-is@^0.1.3, deep-is@~0.1.3:
+deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 deepmerge@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
-  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 defer-to-connect@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
-define-properties@^1.1.3, define-properties@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
-  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
+  integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
@@ -5232,9 +4724,9 @@ dir-glob@^3.0.1:
     path-type "^4.0.0"
 
 docker-modem@^3.0.0:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/docker-modem/-/docker-modem-3.0.6.tgz#8c76338641679e28ec2323abb65b3276fb1ce597"
-  integrity sha512-h0Ow21gclbYsZ3mkHDfsYNDqtRhXS8fXr51bU0qr1dxgTMJj0XufbzX+jhNOvA8KuEEzn6JbvLVhXyv+fny9Uw==
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/docker-modem/-/docker-modem-3.0.8.tgz#ef62c8bdff6e8a7d12f0160988c295ea8705e77a"
+  integrity sha512-f0ReSURdM3pcKPNS30mxOHSbaFLcknGmQjwSfmbcdOw1XWKXVhukM3NJHhr7NpY9BIyyWQb0EBo3KQvvuU5egQ==
   dependencies:
     debug "^4.1.1"
     readable-stream "^3.5.0"
@@ -5242,9 +4734,9 @@ docker-modem@^3.0.0:
     ssh2 "^1.11.0"
 
 dockerode@^3.2.1:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-3.3.4.tgz#875de614a1be797279caa9fe27e5637cf0e40548"
-  integrity sha512-3EUwuXnCU+RUlQEheDjmBE0B7q66PV9Rw5NiH1sXwINq0M9c5ERP9fxgkw36ZHOtzf4AGEEYySnkx/sACC9EgQ==
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-3.3.5.tgz#7ae3f40f2bec53ae5e9a741ce655fff459745629"
+  integrity sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     docker-modem "^3.0.0"
@@ -5285,23 +4777,14 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
+domhandler@^5.0.2, domhandler@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
 
-domutils@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
-  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
-  dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.1"
-
-domutils@^3.1.0:
+domutils@^3.0.1, domutils@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
   integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
@@ -5317,6 +4800,11 @@ duplexer2@~0.1.4:
   dependencies:
     readable-stream "^2.0.2"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -5330,39 +4818,32 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@^3.1.6:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
-  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
-  dependencies:
-    jake "^10.8.5"
-
-ejs@^3.1.9:
+ejs@^3.1.6, ejs@^3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
   integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
   dependencies:
     jake "^10.8.5"
 
-electron-to-chromium@^1.4.251:
-  version "1.4.284"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
-  integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
+electron-to-chromium@^1.4.477:
+  version "1.4.505"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz#00571ade5975b58413f0f56a665b065bfc29cdfc"
+  integrity sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==
 
 emittery@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
   integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 enabled@2.0.x:
   version "2.0.0"
@@ -5382,18 +4863,14 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1, end-of-stream@^1.4.4:
     once "^1.4.0"
 
 enquirer@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
+  integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
   dependencies:
     ansi-colors "^4.1.1"
+    strip-ansi "^6.0.1"
 
-entities@^4.2.0, entities@^4.3.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
-  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
-
-entities@^4.5.0:
+entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -5405,35 +4882,59 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.19.0, es-abstract@^1.20.4:
-  version "1.20.4"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.4.tgz#1d103f9f8d78d4cf0713edcd6d0ed1a46eed5861"
-  integrity sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==
+es-abstract@^1.20.4, es-abstract@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.22.1.tgz#8b4e5fc5cefd7f1660f0f8e1a52900dfbc9d9ccc"
+  integrity sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==
   dependencies:
+    array-buffer-byte-length "^1.0.0"
+    arraybuffer.prototype.slice "^1.0.1"
+    available-typed-arrays "^1.0.5"
     call-bind "^1.0.2"
+    es-set-tostringtag "^2.0.1"
     es-to-primitive "^1.2.1"
-    function-bind "^1.1.1"
     function.prototype.name "^1.1.5"
-    get-intrinsic "^1.1.3"
+    get-intrinsic "^1.2.1"
     get-symbol-description "^1.0.0"
+    globalthis "^1.0.3"
+    gopd "^1.0.1"
     has "^1.0.3"
     has-property-descriptors "^1.0.0"
+    has-proto "^1.0.1"
     has-symbols "^1.0.3"
-    internal-slot "^1.0.3"
+    internal-slot "^1.0.5"
+    is-array-buffer "^3.0.2"
     is-callable "^1.2.7"
     is-negative-zero "^2.0.2"
     is-regex "^1.1.4"
     is-shared-array-buffer "^1.0.2"
     is-string "^1.0.7"
+    is-typed-array "^1.1.10"
     is-weakref "^1.0.2"
-    object-inspect "^1.12.2"
+    object-inspect "^1.12.3"
     object-keys "^1.1.1"
     object.assign "^4.1.4"
-    regexp.prototype.flags "^1.4.3"
+    regexp.prototype.flags "^1.5.0"
+    safe-array-concat "^1.0.0"
     safe-regex-test "^1.0.0"
-    string.prototype.trimend "^1.0.5"
-    string.prototype.trimstart "^1.0.5"
+    string.prototype.trim "^1.2.7"
+    string.prototype.trimend "^1.0.6"
+    string.prototype.trimstart "^1.0.6"
+    typed-array-buffer "^1.0.0"
+    typed-array-byte-length "^1.0.0"
+    typed-array-byte-offset "^1.0.0"
+    typed-array-length "^1.0.4"
     unbox-primitive "^1.0.2"
+    which-typed-array "^1.1.10"
+
+es-set-tostringtag@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"
+  integrity sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==
+  dependencies:
+    get-intrinsic "^1.1.3"
+    has "^1.0.3"
+    has-tostringtag "^1.0.0"
 
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
@@ -5477,46 +4978,33 @@ escape-string-regexp@^4.0.0:
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
-  integrity sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
+  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
   dependencies:
     esprima "^4.0.1"
     estraverse "^5.2.0"
     esutils "^2.0.2"
-    optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-es@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-es/-/eslint-config-es-4.1.0.tgz#bef594038abc5b0ca79a3adbb04222d9e201748a"
-  integrity sha512-o7sRistJAqsiVB437ptIodjcBTz+JwUj2youjU9P2zIJMHZOY2eRpEnIMhqOusbWDVqPKefp+3hPSI/qFotECQ==
+eslint-config-es@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-es/-/eslint-config-es-4.2.0.tgz#1557543ad8a3b02d0b268c7d7292a0f4919657ea"
+  integrity sha512-VpM6q45ie7GjDLHB0BdOC5UDGEpFOFWBBEE+zKHz1ZBoQaYEK32YufOgk1rnzpEsMCg3NgVnM9Kt3pE1+o4CZQ==
   dependencies:
     lodash "4.17.21"
 
-eslint-config-es@^3.23.0:
-  version "3.31.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-es/-/eslint-config-es-3.31.0.tgz#4a99c0ccd8cae0c2e3a51fdb37c670937a442428"
-  integrity sha512-pZ4MeGYBS64FVoP5WVzLr2PdABGT/KdFvVbqgHd+9IvigRPT+h8hoLpAc7KwQ7Z1SEFch9b5cOriXgIX/0zAjw==
-  dependencies:
-    "@typescript-eslint/eslint-plugin" "5.2.0"
-    "@typescript-eslint/parser" "5.2.0"
-    eslint-plugin-eslint-comments "3.2.0"
-    eslint-plugin-extended "0.2.0"
-    eslint-plugin-mocha "9.0.0"
-    eslint-plugin-react "7.26.1"
-    eslint-plugin-unicorn "37.0.1"
-
 eslint-import-resolver-node@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
-  integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz#d4eaac52b8a2e7c3cd1903eb00f7e053356118ac"
+  integrity sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==
   dependencies:
     debug "^3.2.7"
-    resolve "^1.20.0"
+    is-core-module "^2.13.0"
+    resolve "^1.22.4"
 
-eslint-import-resolver-typescript@^2.3.0, eslint-import-resolver-typescript@^2.5.0:
+eslint-import-resolver-typescript@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz#a90a4a1c80da8d632df25994c4c5fdcdd02b8751"
   integrity sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==
@@ -5527,10 +5015,10 @@ eslint-import-resolver-typescript@^2.3.0, eslint-import-resolver-typescript@^2.5
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-module-utils@^2.7.2, eslint-module-utils@^2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
-  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
+eslint-module-utils@^2.7.3:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz#e439fee65fc33f6bba630ff621efc38ec0375c49"
+  integrity sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==
   dependencies:
     debug "^3.2.7"
 
@@ -5549,26 +5037,7 @@ eslint-plugin-extended@0.2.0:
   dependencies:
     varname "2.0.2"
 
-eslint-plugin-import@2.25.4:
-  version "2.25.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
-  integrity sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==
-  dependencies:
-    array-includes "^3.1.4"
-    array.prototype.flat "^1.2.5"
-    debug "^2.6.9"
-    doctrine "^2.1.0"
-    eslint-import-resolver-node "^0.3.6"
-    eslint-module-utils "^2.7.2"
-    has "^1.0.3"
-    is-core-module "^2.8.0"
-    is-glob "^4.0.3"
-    minimatch "^3.0.4"
-    object.values "^1.1.5"
-    resolve "^1.20.0"
-    tsconfig-paths "^3.12.0"
-
-eslint-plugin-import@^2.22.0:
+eslint-plugin-import@2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
   integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
@@ -5587,13 +5056,6 @@ eslint-plugin-import@^2.22.0:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-plugin-jest@^24.0.2:
-  version "24.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz#206ac0833841e59e375170b15f8d0955219c4889"
-  integrity sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "^4.0.1"
-
 eslint-plugin-jest@^26.0.0:
   version "26.9.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.9.0.tgz#7931c31000b1c19e57dbfb71bbf71b817d1bf949"
@@ -5609,52 +5071,32 @@ eslint-plugin-mocha@9.0.0:
     eslint-utils "^3.0.0"
     ramda "^0.27.1"
 
-eslint-plugin-react-hooks@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz#318dbf312e06fab1c835a4abef00121751ac1172"
-  integrity sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==
+eslint-plugin-react-hooks@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
-eslint-plugin-react@7.26.1:
-  version "7.26.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz#41bcfe3e39e6a5ac040971c1af94437c80daa40e"
-  integrity sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==
+eslint-plugin-react@7.31.10:
+  version "7.31.10"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz#6782c2c7fe91c09e715d536067644bbb9491419a"
+  integrity sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==
   dependencies:
-    array-includes "^3.1.3"
-    array.prototype.flatmap "^1.2.4"
-    doctrine "^2.1.0"
-    estraverse "^5.2.0"
-    jsx-ast-utils "^2.4.1 || ^3.0.0"
-    minimatch "^3.0.4"
-    object.entries "^1.1.4"
-    object.fromentries "^2.0.4"
-    object.hasown "^1.0.0"
-    object.values "^1.1.4"
-    prop-types "^15.7.2"
-    resolve "^2.0.0-next.3"
-    semver "^6.3.0"
-    string.prototype.matchall "^4.0.5"
-
-eslint-plugin-react@7.29.3:
-  version "7.29.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz#f4eab757f2756d25d6d4c2a58a9e20b004791f05"
-  integrity sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==
-  dependencies:
-    array-includes "^3.1.4"
-    array.prototype.flatmap "^1.2.5"
+    array-includes "^3.1.5"
+    array.prototype.flatmap "^1.3.0"
     doctrine "^2.1.0"
     estraverse "^5.3.0"
     jsx-ast-utils "^2.4.1 || ^3.0.0"
     minimatch "^3.1.2"
     object.entries "^1.1.5"
     object.fromentries "^2.0.5"
-    object.hasown "^1.1.0"
+    object.hasown "^1.1.1"
     object.values "^1.1.5"
     prop-types "^15.8.1"
     resolve "^2.0.0-next.3"
     semver "^6.3.0"
-    string.prototype.matchall "^4.0.6"
+    string.prototype.matchall "^4.0.7"
 
-eslint-plugin-tsdoc@^0.2.14, eslint-plugin-tsdoc@^0.2.7:
+eslint-plugin-tsdoc@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz#27789495bbd8778abbf92db1707fec2ed3dfe281"
   integrity sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==
@@ -5683,17 +5125,6 @@ eslint-plugin-unicorn@37.0.1:
     semver "^7.3.5"
     strip-indent "^3.0.0"
 
-eslint-plugin-unused-imports@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-0.1.3.tgz#e7ba892576218218f793653d5337081c7ee0f991"
-  integrity sha512-hNbmvUhfy+Nf+9t2Sx720FsFRMkpWLaN5QSw0yUyplcOugvnRaLg9ylAK6DFu/S3J+IiPiHueZHKJh7lhggAXA==
-  dependencies:
-    "@typescript-eslint/eslint-plugin" "^2.3.0"
-    eslint "^6.3.0"
-    eslint-rule-composer "^0.3.0"
-    requireindex "~1.1.0"
-    typescript "^3.6.3"
-
 eslint-plugin-unused-imports@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
@@ -5706,7 +5137,7 @@ eslint-rule-composer@^0.3.0:
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
   integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
-eslint-scope@5.1.1, eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -5725,14 +5156,7 @@ eslint-template-visitor@^2.3.2:
     esquery "^1.3.1"
     multimap "^1.1.0"
 
-eslint-utils@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
-  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
-
-eslint-utils@^2.0.0, eslint-utils@^2.1.0:
+eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
@@ -5756,53 +5180,10 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
-  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
-
-eslint@^6.3.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
-  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    ajv "^6.10.0"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.5"
-    debug "^4.0.1"
-    doctrine "^3.0.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^1.4.3"
-    eslint-visitor-keys "^1.1.0"
-    espree "^6.1.2"
-    esquery "^1.0.1"
-    esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^5.0.0"
-    globals "^12.1.0"
-    ignore "^4.0.6"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    inquirer "^7.0.0"
-    is-glob "^4.0.0"
-    js-yaml "^3.13.1"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.14"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    optionator "^0.8.3"
-    progress "^2.0.0"
-    regexpp "^2.0.1"
-    semver "^6.1.2"
-    strip-ansi "^5.2.0"
-    strip-json-comments "^3.0.1"
-    table "^5.2.3"
-    text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
+eslint-visitor-keys@^3.3.0:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
 eslint@^7.9.0:
   version "7.32.0"
@@ -5850,15 +5231,6 @@ eslint@^7.9.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^6.1.2:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
-  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
-  dependencies:
-    acorn "^7.1.1"
-    acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.1.0"
-
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -5873,10 +5245,10 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1, esquery@^1.3.1, esquery@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
-  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+esquery@^1.3.1, esquery@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -6007,15 +5379,6 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
-  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
-  dependencies:
-    chardet "^0.7.0"
-    iconv-lite "^0.4.24"
-    tmp "^0.0.33"
-
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -6046,9 +5409,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.2.9:
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
-  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -6061,15 +5424,15 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
-  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
+  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
 
@@ -6125,20 +5488,6 @@ fetch-sparql-endpoint@^4.0.0:
     sparqlxml-parse "^2.1.1"
     stream-to-string "^1.1.0"
 
-figures@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
-  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
-  dependencies:
-    escape-string-regexp "^1.0.5"
-
-file-entry-cache@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
-  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
-  dependencies:
-    flat-cache "^2.0.1"
-
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -6146,7 +5495,7 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-filelist@^1.0.1:
+filelist@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
   integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
@@ -6193,29 +5542,16 @@ find-versions@^4.0.0:
   dependencies:
     semver-regex "^3.1.2"
 
-flat-cache@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
-  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
-  dependencies:
-    flatted "^2.0.0"
-    rimraf "2.6.3"
-    write "1.0.3"
-
 flat-cache@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
-  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.1.0.tgz#0e54ab4a1a60fe87e2946b6b00657f1c99e1af3f"
+  integrity sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==
   dependencies:
-    flatted "^3.1.0"
+    flatted "^3.2.7"
+    keyv "^4.5.3"
     rimraf "^3.0.2"
 
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
-
-flatted@^3.1.0:
+flatted@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
@@ -6225,10 +5561,25 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==
+
+foreground-child@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d"
+  integrity sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^4.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -6304,9 +5655,9 @@ fs.realpath@^1.0.0:
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 fsevents@^2.1.2, fsevents@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 fstream@^1.0.12:
   version "1.0.12"
@@ -6324,21 +5675,21 @@ function-bind@^1.1.1:
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 function.prototype.name@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
-  integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.6.tgz#cdf315b7d90ee77a4c6ee216c3c3362da07533fd"
+  integrity sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    es-abstract "^1.19.0"
-    functions-have-names "^1.2.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    functions-have-names "^1.2.3"
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
 
-functions-have-names@^1.2.2:
+functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
@@ -6353,13 +5704,14 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
-  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
+  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
+    has-proto "^1.0.1"
     has-symbols "^1.0.3"
 
 get-package-type@^0.1.0:
@@ -6430,14 +5782,25 @@ git-semver-tags@^4.0.0:
     meow "^8.0.0"
     semver "^6.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.2:
+glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@^10.2.5:
+  version "10.3.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.3.tgz#8360a4ffdd6ed90df84aa8d52f21f452e86a123b"
+  integrity sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^2.0.3"
+    minimatch "^9.0.1"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+    path-scurry "^1.10.1"
+
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -6454,21 +5817,21 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^12.1.0:
-  version "12.4.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
-  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
-  dependencies:
-    type-fest "^0.8.1"
-
 globals@^13.6.0, globals@^13.9.0:
-  version "13.20.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
-  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
+  version "13.21.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.21.0.tgz#163aae12f34ef502f5153cfbdd3600f36c63c571"
+  integrity sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
+globalthis@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
+  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
+  dependencies:
+    define-properties "^1.1.3"
+
+globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -6480,10 +5843,17 @@ globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 got@^11.8.2:
-  version "11.8.5"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
-  integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
+  version "11.8.6"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
+  integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
   dependencies:
     "@sindresorhus/is" "^4.0.0"
     "@szmarczak/http-timer" "^4.0.5"
@@ -6498,9 +5868,14 @@ got@^11.8.2:
     responselike "^2.0.0"
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
-  version "4.2.10"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
-  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 graphql-to-sparql@^3.0.1:
   version "3.0.1"
@@ -6525,12 +5900,12 @@ growly@^1.3.0:
   integrity sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==
 
 handlebars@^4.7.7:
-  version "4.7.7"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
-  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
   dependencies:
     minimist "^1.2.5"
-    neo-async "^2.6.0"
+    neo-async "^2.6.2"
     source-map "^0.6.1"
     wordwrap "^1.0.0"
   optionalDependencies:
@@ -6575,6 +5950,11 @@ has-property-descriptors@^1.0.0:
   integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
   dependencies:
     get-intrinsic "^1.1.1"
+
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
 
 has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
@@ -6658,15 +6038,15 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-htmlparser2@^8.0.0, htmlparser2@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.1.tgz#abaa985474fcefe269bc761a779b544d7196d010"
-  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
+htmlparser2@^8.0.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
+  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
   dependencies:
     domelementtype "^2.3.0"
-    domhandler "^5.0.2"
+    domhandler "^5.0.3"
     domutils "^3.0.1"
-    entities "^4.3.0"
+    entities "^4.4.0"
 
 htmlparser2@^9.0.0:
   version "9.0.0"
@@ -6687,9 +6067,9 @@ http-assert@^1.3.0:
     http-errors "~1.8.0"
 
 http-cache-semantics@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
 http-errors@2.0.0:
   version "2.0.0"
@@ -6714,9 +6094,9 @@ http-errors@^1.6.3, http-errors@~1.8.0:
     toidentifier "1.0.1"
 
 http-link-header@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/http-link-header/-/http-link-header-1.1.0.tgz#a1ca87efdbcb7778d8d0d4525de1e6964ec1f129"
-  integrity sha512-pj6N1yxOz/ANO8HHsWGg/OoIL1kmRYvQnXQ7PIRpgp+15AnEsRH8fmIJE6D1OdWG2Bov+BJHVla1fFXxg1JbbA==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/http-link-header/-/http-link-header-1.1.1.tgz#f0e6971b0ed86e858d2077066ecb7ba4f2e50de9"
+  integrity sha512-mW3N/rTYpCn99s1do0zx6nzFZSwLH9HGfUM4ZqLWJ16ylmYaC2v5eYGqrNTQlByx8AzUgGI+V/32gXPugs1+Sw==
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"
@@ -6773,7 +6153,7 @@ husky@^4.2.5:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6791,19 +6171,14 @@ ignore@^4.0.6:
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 ignore@^5.0.5, ignore@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.1.tgz#c2b1f76cb999ede1502f3a226a9310fdfe88d46c"
-  integrity sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==
-
-ignore@^5.1.8:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 immutable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
-  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.4.tgz#2e07b33837b4bb7662f288c244d1ced1ef65a78f"
+  integrity sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -6844,31 +6219,12 @@ inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inquirer@^7.0.0:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
-  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+internal-slot@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
+  integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
   dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.0"
-    cli-cursor "^3.1.0"
-    cli-width "^3.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.19"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.6.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-
-internal-slot@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
-  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
-  dependencies:
-    get-intrinsic "^1.1.0"
+    get-intrinsic "^1.2.0"
     has "^1.0.3"
     side-channel "^1.0.4"
 
@@ -6901,6 +6257,15 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
+  integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.0"
+    is-typed-array "^1.1.10"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -6932,13 +6297,13 @@ is-buffer@^1.1.5:
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-builtin-module@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.0.tgz#bb0310dfe881f144ca83f30100ceb10cf58835e0"
-  integrity sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
   dependencies:
     builtin-modules "^3.3.0"
 
-is-callable@^1.1.4, is-callable@^1.2.7:
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
@@ -6950,10 +6315,10 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.1.0, is-core-module@^2.5.0, is-core-module@^2.8.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
-  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+is-core-module@^2.1.0, is-core-module@^2.13.0, is-core-module@^2.5.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
   dependencies:
     has "^1.0.3"
 
@@ -7017,11 +6382,6 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
-
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -7127,6 +6487,13 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
+is-typed-array@^1.1.10, is-typed-array@^1.1.9:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
+  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
+  dependencies:
+    which-typed-array "^1.1.11"
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -7155,6 +6522,11 @@ isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -7210,12 +6582,12 @@ istanbul-lib-instrument@^5.0.4:
     semver "^6.3.0"
 
 istanbul-lib-report@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
-  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
   dependencies:
     istanbul-lib-coverage "^3.0.0"
-    make-dir "^3.0.0"
+    make-dir "^4.0.0"
     supports-color "^7.1.0"
 
 istanbul-lib-source-maps@^4.0.0:
@@ -7228,22 +6600,31 @@ istanbul-lib-source-maps@^4.0.0:
     source-map "^0.6.1"
 
 istanbul-reports@^3.0.2:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.5.tgz#cc9a6ab25cb25659810e4785ed9d9fb742578bae"
-  integrity sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.6.tgz#2544bcab4768154281a2f0870471902704ccaa1a"
+  integrity sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jackspeak@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.1.tgz#ce2effa4c458e053640e61938865a5b5fae98456"
+  integrity sha512-4iSY3Bh1Htv+kLhiiZunUhQ+OYXIn0ze3ulq8JeWrFKmhPAJSySV2+kdtRh2pGcCeF0s6oR8Oc+pYZynJj4t8A==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 jake@^10.8.5:
-  version "10.8.5"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
-  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
+  version "10.8.7"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.7.tgz#63a32821177940c33f356e0ba44ff9d34e1c7d8f"
+  integrity sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==
   dependencies:
     async "^3.2.3"
     chalk "^4.0.2"
-    filelist "^1.0.1"
-    minimatch "^3.0.4"
+    filelist "^1.0.4"
+    minimatch "^3.1.2"
 
 jest-changed-files@^26.6.2:
   version "26.6.2"
@@ -7690,12 +7071,7 @@ jju@~1.4.0:
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
 
-jose@^4.1.4, jose@^4.10.3:
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.11.1.tgz#8f7443549befe5bddcf4bae664a9cbc1a62da4fa"
-  integrity sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==
-
-jose@^4.14.1:
+jose@^4.1.4, jose@^4.10.3, jose@^4.14.1:
   version "4.14.4"
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.14.4.tgz#59e09204e2670c3164ee24cbfe7115c6f8bff9ca"
   integrity sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==
@@ -7796,15 +7172,15 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@2.x, json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@2.x, json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+json5@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
@@ -7817,19 +7193,7 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonld-context-parser@^2.0.0, jsonld-context-parser@^2.0.2, jsonld-context-parser@^2.1.1, jsonld-context-parser@^2.1.3, jsonld-context-parser@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/jsonld-context-parser/-/jsonld-context-parser-2.2.2.tgz#2c206b022eddd335bb7477046e1bd6dfb4322c34"
-  integrity sha512-3VWIg/4NCMTXP6NsI6O93spFTd4qIOucKEmD8I+Exhxk9ZUVrnkLp2G4f0toR5jVleZkiiB9YGPS+yT1wwMqnQ==
-  dependencies:
-    "@types/http-link-header" "^1.0.1"
-    "@types/node" "^18.0.0"
-    canonicalize "^1.0.1"
-    cross-fetch "^3.0.6"
-    http-link-header "^1.0.2"
-    relative-to-absolute-iri "^1.0.5"
-
-jsonld-context-parser@^2.3.0:
+jsonld-context-parser@^2.0.0, jsonld-context-parser@^2.0.2, jsonld-context-parser@^2.1.1, jsonld-context-parser@^2.2.2, jsonld-context-parser@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/jsonld-context-parser/-/jsonld-context-parser-2.3.0.tgz#423a36114bd7876477dabef105efe49cc79fb59b"
   integrity sha512-c6w2GE57O26eWFjcPX6k6G86ootsIfpuVwhZKjCll0bVoDGBxr1P4OuU+yvgfnh1GJhAGErolfC7W1BklLjWMg==
@@ -7842,22 +7206,22 @@ jsonld-context-parser@^2.3.0:
     relative-to-absolute-iri "^1.0.5"
 
 jsonld-streaming-parser@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonld-streaming-parser/-/jsonld-streaming-parser-3.0.1.tgz#6503bacbc8640bb6eacafc29bcac583af5205407"
-  integrity sha512-zSJlEgrKypQDk/85R+xkudeCZo6vmnvJuCPvcjk2BzHPLzv1yqiwoKQDyFzfgfgCHM0p7YCJBZl0liT9RMUZJw==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsonld-streaming-parser/-/jsonld-streaming-parser-3.2.0.tgz#b879eae6389617746b24101e5a04eba60af0a15d"
+  integrity sha512-lJR1SCT364PGpFrOQaY+ZQ7qDWqqiT3IMK+AvZ83fo0LvltFn8/UyXvIFc3RO7YcaEjLahAF0otCi8vOq21NtQ==
   dependencies:
+    "@bergos/jsonparse" "^1.4.0"
     "@rdfjs/types" "*"
     "@types/http-link-header" "^1.0.1"
     "@types/readable-stream" "^2.3.13"
     buffer "^6.0.3"
     canonicalize "^1.0.1"
     http-link-header "^1.0.2"
-    jsonld-context-parser "^2.1.3"
-    jsonparse "^1.3.1"
+    jsonld-context-parser "^2.3.0"
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
 
-jsonld-streaming-serializer@^2.0.1, jsonld-streaming-serializer@^2.1.0:
+jsonld-streaming-serializer@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz#db80d6e13d74ae5837a313123ea4d409b04df2e0"
   integrity sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==
@@ -7867,11 +7231,6 @@ jsonld-streaming-serializer@^2.0.1, jsonld-streaming-serializer@^2.1.0:
     buffer "^6.0.3"
     jsonld-context-parser "^2.0.0"
     readable-stream "^4.0.0"
-
-jsonparse@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
-  integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
 jsprim@^1.2.2:
   version "1.4.2"
@@ -7884,12 +7243,14 @@ jsprim@^1.2.2:
     verror "1.10.0"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
-  integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"
+  integrity sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==
   dependencies:
-    array-includes "^3.1.5"
-    object.assign "^4.1.3"
+    array-includes "^3.1.6"
+    array.prototype.flat "^1.3.1"
+    object.assign "^4.1.4"
+    object.values "^1.1.6"
 
 keygrip@~1.1.0:
   version "1.1.0"
@@ -7898,10 +7259,10 @@ keygrip@~1.1.0:
   dependencies:
     tsscmp "1.0.6"
 
-keyv@^4.0.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.2.tgz#0e310ce73bf7851ec702f2eaf46ec4e3805cce56"
-  integrity sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==
+keyv@^4.0.0, keyv@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.3.tgz#00873d2b046df737963157bd04f294ca818c9c25"
+  integrity sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==
   dependencies:
     json-buffer "3.0.1"
 
@@ -7948,9 +7309,9 @@ koa-convert@^2.0.0:
     koa-compose "^4.1.0"
 
 koa@^2.13.3:
-  version "2.13.4"
-  resolved "https://registry.yarnpkg.com/koa/-/koa-2.13.4.tgz#ee5b0cb39e0b8069c38d115139c774833d32462e"
-  integrity sha512-43zkIKubNbnrULWlHdN5h1g3SEKXOEzoAlRsHOTFpnlDu8JlAOZSMJBLULusuXRequboiwJcj5vtYXKB3k7+2g==
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/koa/-/koa-2.14.2.tgz#a57f925c03931c2b4d94b19d2ebf76d3244863fc"
+  integrity sha512-VFI2bpJaodz6P7x2uyLiX6RLYpZmOJqNmoCst/Yyd7hQlszyPwG/I9CQJ63nOtKSxpt5M7NH67V6nJL2BwCl7g==
   dependencies:
     accepts "^1.3.5"
     cache-content-type "^1.0.0"
@@ -8016,14 +7377,6 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-levn@^0.3.0, levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -8081,7 +7434,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4.17.21, lodash@4.x, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@4.x, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8092,11 +7445,12 @@ log-driver@^1.2.7:
   integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
 logform@^2.3.2, logform@^2.4.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/logform/-/logform-2.4.2.tgz#a617983ac0334d0c3b942c34945380062795b47c"
-  integrity sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.5.1.tgz#44c77c34becd71b3a42a3970c77929e52c6ed48b"
+  integrity sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==
   dependencies:
     "@colors/colors" "1.5.0"
+    "@types/triple-beam" "^1.3.2"
     fecha "^4.2.0"
     ms "^2.1.1"
     safe-stable-stringify "^2.3.1"
@@ -8114,10 +7468,17 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@*, lru-cache@^10.0.0:
+lru-cache@*, lru-cache@^10.0.0, "lru-cache@^9.1.1 || ^10.0.0":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
   integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -8126,12 +7487,12 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-make-dir@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
-  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
   dependencies:
-    semver "^6.0.0"
+    semver "^7.5.3"
 
 make-error@1.x:
   version "1.3.6"
@@ -8298,9 +7659,16 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
     brace-expansion "^1.1.7"
 
 minimatch@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
-  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.1:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -8314,9 +7682,14 @@ minimist-options@4.1.0:
     kind-of "^6.0.3"
 
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
-  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.3.tgz#05ea638da44e475037ed94d1c7efcc76a25e1974"
+  integrity sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -8336,7 +7709,7 @@ mkdirp@1.x, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.1:
+"mkdirp@>=0.5 0":
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -8363,20 +7736,7 @@ multimap@^1.1.0:
   resolved "https://registry.yarnpkg.com/multimap/-/multimap-1.1.0.tgz#5263febc085a1791c33b59bb3afc6a76a2a10ca8"
   integrity sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==
 
-mute-stream@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
-  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
-
-n3@^1.16.2, n3@^1.16.3, n3@^1.6.3:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/n3/-/n3-1.16.3.tgz#d339dca14c79648b1595a3252c5410b800b896f8"
-  integrity sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==
-  dependencies:
-    queue-microtask "^1.1.2"
-    readable-stream "^4.0.0"
-
-n3@^1.16.4, n3@^1.17.0:
+n3@^1.16.2, n3@^1.16.3, n3@^1.16.4, n3@^1.17.0, n3@^1.6.3:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.17.1.tgz#cb42f39507cebebf2c990c2f8a3f5f53232c518c"
   integrity sha512-HlanMWpvN2kcTrFuU3GPObyY7qrVQWy2Hp7l4GSXJlcQapjQMR7OM4kCr788pTQzNIpiHS3JRvyZ2YUcYJ82rA==
@@ -8384,15 +7744,15 @@ n3@^1.16.4, n3@^1.17.0:
     queue-microtask "^1.1.2"
     readable-stream "^4.0.0"
 
-nan@^2.15.0, nan@^2.16.0:
+nan@^2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
 nanoid@^3.1.28:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -8431,7 +7791,7 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-neo-async@^2.6.0:
+neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -8441,14 +7801,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.7, node-fetch@^2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@^2.6.12:
+node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -8472,10 +7825,10 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-releases@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
-  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
+node-releases@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
+  integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
 
 nodemailer@^6.9.1:
   version "6.9.4"
@@ -8534,9 +7887,9 @@ npm-run-path@^4.0.0:
     path-key "^3.0.0"
 
 nwsapi@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
-  integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
+  integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -8562,10 +7915,10 @@ object-hash@^2.2.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
   integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
-object-inspect@^1.12.2, object-inspect@^1.9.0:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
-  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+object-inspect@^1.12.2, object-inspect@^1.12.3, object-inspect@^1.9.0:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
+  integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -8579,7 +7932,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.1.3, object.assign@^4.1.4:
+object.assign@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
   integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
@@ -8589,31 +7942,31 @@ object.assign@^4.1.3, object.assign@^4.1.4:
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
-object.entries@^1.1.4, object.entries@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.6.tgz#9737d0e5b8291edd340a3e3264bb8a3b00d5fa23"
-  integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==
+object.entries@^1.1.5:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.7.tgz#2b47760e2a2e3a752f39dd874655c61a7f03c131"
+  integrity sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.4"
-    es-abstract "^1.20.4"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
 
-object.fromentries@^2.0.4, object.fromentries@^2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.6.tgz#cdb04da08c539cffa912dcd368b886e0904bfa73"
-  integrity sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==
+object.fromentries@^2.0.5:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.7.tgz#71e95f441e9a0ea6baf682ecaaf37fa2a8d7e616"
+  integrity sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.4"
-    es-abstract "^1.20.4"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
 
-object.hasown@^1.0.0, object.hasown@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.2.tgz#f919e21fad4eb38a57bc6345b3afd496515c3f92"
-  integrity sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==
+object.hasown@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.3.tgz#6a5f2897bb4d3668b8e79364f98ccf971bda55ae"
+  integrity sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==
   dependencies:
-    define-properties "^1.1.4"
-    es-abstract "^1.20.4"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -8622,14 +7975,14 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-object.values@^1.1.4, object.values@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.6.tgz#4abbaa71eba47d63589d402856f908243eea9b1d"
-  integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
+object.values@^1.1.5, object.values@^1.1.6:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.7.tgz#617ed13272e7e1071b43973aa1655d9291b8442a"
+  integrity sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.4"
-    es-abstract "^1.20.4"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
 
 oidc-provider@7.10.6:
   version "7.10.6"
@@ -8655,9 +8008,9 @@ oidc-provider@7.10.6:
     paseto3 "npm:paseto@^3.0.0"
 
 oidc-token-hash@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
-  integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz#9a229f0a1ce9d4fc89bcaee5478c97a889e7b7b6"
+  integrity sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==
 
 on-finished@^2.3.0:
   version "2.4.1"
@@ -8697,34 +8050,17 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
-optionator@^0.8.1, optionator@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
-  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
-  dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.6"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    word-wrap "~1.2.3"
-
 optionator@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
-  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
+  integrity sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==
   dependencies:
+    "@aashutoshrathi/word-wrap" "^1.2.3"
     deep-is "^0.1.3"
     fast-levenshtein "^2.0.6"
     levn "^0.4.1"
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
-    word-wrap "^1.2.3"
-
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 p-cancelable@^2.0.0:
   version "2.1.1"
@@ -8812,9 +8148,9 @@ pascalcase@^0.1.1:
   integrity sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==
 
 "paseto3@npm:paseto@^3.0.0":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/paseto/-/paseto-3.1.2.tgz#55a1acde1ab1f0078c62e28726681ffadff5fd96"
-  integrity sha512-TNmRcQFF7xRnkLnJ07gCD5lRB273V4fU1pCy8G2P9CQjffIzKMYa3e8yo6LlrCCjIdv4jjS85Cfz86hl5SHzng==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/paseto/-/paseto-3.1.4.tgz#a8a448abadb20fef609e00a4fd6d82369b3ea05a"
+  integrity sha512-BifaKKu+MS9b/vTgFMC6Q8uLUMqw8VtYgl4qODJWb6Jqt+dTKn8XH9EftJZx+6wxF4ELBbKdH33DZa4inMYVcg==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -8841,6 +8177,14 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.1.tgz#9ba6bf5aa8500fe9fd67df4f0d9483b2b0bfc698"
+  integrity sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==
+  dependencies:
+    lru-cache "^9.1.1 || ^10.0.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -8862,9 +8206,9 @@ picomatch@^2.0.4, picomatch@^2.3.1:
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pirates@^4.0.1:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
-  integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
+  integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -8901,11 +8245,6 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
-prelude-ls@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-  integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
 pretty-format@^22.4.3:
   version "22.4.3"
@@ -8963,7 +8302,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8995,9 +8334,9 @@ pump@^3.0.0:
     once "^1.3.1"
 
 punycode@^2.1.0, punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
 qs@~6.5.2:
   version "6.5.3"
@@ -9030,23 +8369,16 @@ ramda@^0.27.1:
   integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
 
 raw-body@^2.4.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
-  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
+  integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
   dependencies:
     bytes "3.1.2"
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz#370142794e2299846896e9c0fafd35e5128c8e5f"
-  integrity sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==
-  dependencies:
-    "@rdfjs/types" "*"
-
-rdf-data-factory@^1.1.2:
+rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1, rdf-data-factory@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz#d47550d2649d0d64f8cae3fcc9efae7a8a895d9a"
   integrity sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==
@@ -9135,10 +8467,10 @@ rdf-literal@^1.2.0, rdf-literal@^1.3.0:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-object@^1.13.1:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/rdf-object/-/rdf-object-1.13.2.tgz#d55a6af9f9439994b5399039e9ec8e039514fed6"
-  integrity sha512-DVLDCbxPOkhd/k43j9wcLU7CXe/gdldBBomMV3RyZ1G9E2zPa2FFNFijzMGgRGNY1OEyGmhBxw2eiJjUC7GVNw==
+rdf-object@^1.13.1, rdf-object@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/rdf-object/-/rdf-object-1.14.0.tgz#a51a2e575d4f838f88eced1e5096616769d17281"
+  integrity sha512-/KSUWr7onDtL7d81kOpcUzJ2vHYOYJc2KU9WzBZRYydBhK0Sksh5Hg4VCQNaxUEvYEgdrrTuq9SLpOOCmag0rQ==
   dependencies:
     "@rdfjs/types" "*"
     jsonld-context-parser "^2.0.2"
@@ -9146,35 +8478,7 @@ rdf-object@^1.13.1:
     rdf-string "^1.6.0"
     streamify-array "^1.0.1"
 
-rdf-parse@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/rdf-parse/-/rdf-parse-2.1.1.tgz#c80d1cd8f3ca8d01d9c7b7d056f73316e2f4edd1"
-  integrity sha512-JOTB7381bAdvab9ZM8IZq6Egj9tuTt7XSGlrQzDCFrlAjvc7z4cMxKawgk1kZaoS/CevNSrHYsyEaBwgNyl1KA==
-  dependencies:
-    "@comunica/actor-http-fetch" "^2.0.1"
-    "@comunica/actor-http-proxy" "^2.0.1"
-    "@comunica/actor-rdf-parse-html" "^2.0.1"
-    "@comunica/actor-rdf-parse-html-microdata" "^2.0.1"
-    "@comunica/actor-rdf-parse-html-rdfa" "^2.0.1"
-    "@comunica/actor-rdf-parse-html-script" "^2.0.1"
-    "@comunica/actor-rdf-parse-jsonld" "^2.0.1"
-    "@comunica/actor-rdf-parse-n3" "^2.0.1"
-    "@comunica/actor-rdf-parse-rdfxml" "^2.0.1"
-    "@comunica/actor-rdf-parse-xml-rdfa" "^2.0.1"
-    "@comunica/bus-http" "^2.0.1"
-    "@comunica/bus-init" "^2.0.1"
-    "@comunica/bus-rdf-parse" "^2.0.1"
-    "@comunica/bus-rdf-parse-html" "^2.0.1"
-    "@comunica/config-query-sparql" "^2.0.1"
-    "@comunica/core" "^2.0.1"
-    "@comunica/mediator-combine-pipeline" "^2.0.1"
-    "@comunica/mediator-combine-union" "^2.0.1"
-    "@comunica/mediator-number" "^2.0.1"
-    "@comunica/mediator-race" "^2.0.1"
-    "@rdfjs/types" "*"
-    stream-to-string "^1.2.0"
-
-rdf-parse@^2.3.2:
+rdf-parse@^2.0.0, rdf-parse@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/rdf-parse/-/rdf-parse-2.3.2.tgz#83539491f7e348f34d314c585a18f0ba707e2368"
   integrity sha512-TOeI7FKlyr/GupfGaXZvpMLzvByOrtwt4zHLMuuy3deNGse9QyhHsspVraZam491sIgBogdchzcUqkf2WXnAsg==
@@ -9213,42 +8517,7 @@ rdf-quad@^1.5.0:
     rdf-literal "^1.2.0"
     rdf-string "^1.5.0"
 
-rdf-serialize@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/rdf-serialize/-/rdf-serialize-2.0.1.tgz#ffc743e6643ef7fd665e9d273b25f83b94f1e492"
-  integrity sha512-GjFSp0Nzh4wxs6lpmdTQQBpjKYl8Lt89dR6PYuLp/YkliByR9tf6c+v4O1srFlfeCZ1u6xMarP0V3/CTMPqy8g==
-  dependencies:
-    "@comunica/actor-rdf-serialize-jsonld" "^2.0.1"
-    "@comunica/actor-rdf-serialize-n3" "^2.0.1"
-    "@comunica/bus-init" "^2.0.1"
-    "@comunica/bus-rdf-serialize" "^2.0.1"
-    "@comunica/config-query-sparql" "^2.0.1"
-    "@comunica/core" "^2.0.1"
-    "@comunica/mediator-combine-pipeline" "^2.0.1"
-    "@comunica/mediator-combine-union" "^2.0.1"
-    "@comunica/mediator-race" "^2.0.1"
-    "@rdfjs/types" "*"
-    stream-to-string "^1.2.0"
-
-rdf-serialize@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/rdf-serialize/-/rdf-serialize-2.2.1.tgz#8bebc7037de76f6a8e732b479224bad1ca9f1ddd"
-  integrity sha512-jRKQ8GmvDQzaB/2PIgLCxlNSz05deKbUbFe/EpPNDv/pke+wa7wPw2iWxhggaCqd7Pqq0tMQGkMetBdfB6Jz2g==
-  dependencies:
-    "@comunica/actor-rdf-serialize-jsonld" "^2.6.6"
-    "@comunica/actor-rdf-serialize-n3" "^2.6.6"
-    "@comunica/actor-rdf-serialize-shaclc" "^2.6.0"
-    "@comunica/bus-init" "^2.0.1"
-    "@comunica/bus-rdf-serialize" "^2.0.1"
-    "@comunica/config-query-sparql" "^2.0.1"
-    "@comunica/core" "^2.0.1"
-    "@comunica/mediator-combine-pipeline" "^2.0.1"
-    "@comunica/mediator-combine-union" "^2.0.1"
-    "@comunica/mediator-race" "^2.0.1"
-    "@rdfjs/types" "*"
-    stream-to-string "^1.1.0"
-
-rdf-serialize@^2.2.2:
+rdf-serialize@^2.0.0, rdf-serialize@^2.2.1, rdf-serialize@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/rdf-serialize/-/rdf-serialize-2.2.2.tgz#9e91faec392a281c435f8864c9ee300594825aa2"
   integrity sha512-zzWQMMMmDzocuFLEOcdz8U5AxbdjBvknwFEHXCyw2lklcEjd2OtsvD5NgWQc+zbsWZKxewvDYEXuzhkNAHRv1g==
@@ -9307,15 +8576,7 @@ rdf-string-ttl@^1.3.2:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.2.tgz#f709845d50968c6ea9a5273b64a5e1efd0d5877a"
-  integrity sha512-tr0aStKYRmT6ShmGsA4HikIn6O3ZkCBSLWsRbeKhlPVPZodl0QNuws6HuJdD1rUyo9+MNiDw+3wvFSUz6Iwv/g==
-  dependencies:
-    "@rdfjs/types" "*"
-    rdf-data-factory "^1.1.0"
-
-rdf-string@^1.6.2, rdf-string@^1.6.3:
+rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-string@^1.6.2, rdf-string@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.3.tgz#5c3173fad13e6328698277fb8ff151e3423282ab"
   integrity sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==
@@ -9323,19 +8584,10 @@ rdf-string@^1.6.2, rdf-string@^1.6.3:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-terms@^1.10.0, rdf-terms@^1.11.0:
+rdf-terms@^1.10.0, rdf-terms@^1.11.0, rdf-terms@^1.7.0, rdf-terms@^1.8.2, rdf-terms@^1.9.1:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.11.0.tgz#0c2e3a2b43f1042959c9263af27dab08dc4b084d"
   integrity sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==
-  dependencies:
-    "@rdfjs/types" "*"
-    rdf-data-factory "^1.1.0"
-    rdf-string "^1.6.0"
-
-rdf-terms@^1.7.0, rdf-terms@^1.8.2, rdf-terms@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.9.1.tgz#5f66a773d4b2fe6e071ebc8a2985beff7e0dfd7f"
-  integrity sha512-GrE8CbQSvuVEFRCywMu6VOgV1AFE6X+nFYcAhEc5pwYKI13bUvz4voiVufQiy3V8rzQKu21Sgl+dS2qcJavy7w==
   dependencies:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
@@ -9372,20 +8624,6 @@ rdfa-streaming-parser@^2.0.1:
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
     relative-to-absolute-iri "^1.0.2"
-
-rdfxml-streaming-parser@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.1.tgz#10c16ed3aabe88c59c0ba503b4c54cd8f4588649"
-  integrity sha512-1r7aXfSRCLkBYXGcko/GpSZdHxXKvYaeUi2ulEbB7cLvACD7DNoAA/uW6dsETEhgmsEipJZI7NLqBl2whOse8Q==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@types/readable-stream" "^2.3.13"
-    buffer "^6.0.3"
-    rdf-data-factory "^1.1.0"
-    readable-stream "^4.0.0"
-    relative-to-absolute-iri "^1.0.0"
-    saxes "^6.0.0"
-    validate-iri "^1.0.0"
 
 rdfxml-streaming-parser@^2.2.3:
   version "2.2.3"
@@ -9436,18 +8674,18 @@ readable-stream-node-to-web@^1.0.1:
   integrity sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==
 
 readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
 readable-stream@^2.0.2, readable-stream@~2.3.6:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -9457,25 +8695,16 @@ readable-stream@^2.0.2, readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^4.0.0, readable-stream@^4.1.0, readable-stream@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.2.0.tgz#a7ef523d3b39e4962b0db1a1af22777b10eeca46"
-  integrity sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==
+readable-stream@^4.0.0, readable-stream@^4.1.0, readable-stream@^4.2.0, readable-stream@^4.3.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.4.2.tgz#e6aced27ad3b9d726d8308515b9a1b98dc1b9d13"
+  integrity sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==
   dependencies:
     abort-controller "^3.0.0"
     buffer "^6.0.3"
     events "^3.3.0"
     process "^0.11.10"
-
-readable-stream@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.3.0.tgz#0914d0c72db03b316c9733bb3461d64a3cc50cba"
-  integrity sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==
-  dependencies:
-    abort-controller "^3.0.0"
-    buffer "^6.0.3"
-    events "^3.3.0"
-    process "^0.11.10"
+    string_decoder "^1.3.0"
 
 readable-web-to-node-stream@^3.0.2:
   version "3.0.2"
@@ -9513,25 +8742,20 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     safe-regex "^1.1.0"
 
 regexp-tree@^0.1.23, regexp-tree@~0.1.1:
-  version "0.1.24"
-  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.24.tgz#3d6fa238450a4d66e5bc9c4c14bb720e2196829d"
-  integrity sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.27.tgz#2198f0ef54518ffa743fe74d983b56ffd631b6cd"
+  integrity sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==
 
-regexp.prototype.flags@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
-  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+regexp.prototype.flags@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+  integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    functions-have-names "^1.2.2"
+    define-properties "^1.2.0"
+    functions-have-names "^1.2.3"
 
-regexpp@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
-  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
-
-regexpp@^3.0.0, regexpp@^3.1.0, regexpp@^3.2.0:
+regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -9597,11 +8821,6 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-requireindex@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
-  integrity sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -9634,12 +8853,12 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
 
-resolve@^1.10.0, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.22.0:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+resolve@^1.10.0, resolve@^1.18.1, resolve@^1.22.0, resolve@^1.22.4:
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.4.tgz#1dc40df46554cdaf8948a486a10f6ba1e2026c34"
+  integrity sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==
   dependencies:
-    is-core-module "^2.9.0"
+    is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -9667,14 +8886,6 @@ responselike@^2.0.0:
   dependencies:
     lowercase-keys "^2.0.0"
 
-restore-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
-  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
-  dependencies:
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -9697,29 +8908,24 @@ rimraf@2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2, rimraf@latest:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
+rimraf@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.1.tgz#0881323ab94ad45fec7c0221f27ea1a142f3f0d0"
+  integrity sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==
+  dependencies:
+    glob "^10.2.5"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
-
-run-async@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
-  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -9728,12 +8934,15 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.6.0:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+safe-array-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.0.tgz#2064223cba3c08d2ee05148eedbc563cd6d84060"
+  integrity sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==
   dependencies:
-    tslib "^1.9.0"
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.0"
+    has-symbols "^1.0.3"
+    isarray "^2.0.5"
 
 safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -9769,9 +8978,9 @@ safe-regex@^2.1.1:
     regexp-tree "~0.1.1"
 
 safe-stable-stringify@^2.3.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz#34694bd8a30575b7f94792aa51527551bd733d61"
-  integrity sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
@@ -9800,13 +9009,6 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-saxes@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
-  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
-  dependencies:
-    xmlchars "^2.2.0"
-
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -9818,21 +9020,21 @@ semver-regex@^3.1.2:
   integrity sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -9919,6 +9121,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -9940,15 +9147,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -10044,21 +9242,7 @@ sparql-query-parameter-instantiator@^2.3.0, sparql-query-parameter-instantiator@
     csv-parser "^3.0.0"
     sparqljs "^3.4.1"
 
-sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz#054cd4dbbe9c2e2ecc345948fd5a7cfad1d475a4"
-  integrity sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@types/sparqljs" "^3.1.3"
-    fast-deep-equal "^3.1.3"
-    minimist "^1.2.6"
-    rdf-data-factory "^1.1.0"
-    rdf-isomorphic "^1.3.0"
-    rdf-string "^1.6.0"
-    sparqljs "^3.6.1"
-
-sparqlalgebrajs@^4.2.0:
+sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.5, sparqlalgebrajs@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.2.0.tgz#b70945bdd2ab2897a0bc22adb804dd1a2b0ec98c"
   integrity sha512-tdlJdrvgQqgx9zubcl9iiyCxMOp4qRT2fs1Sne8X35QTm1Pj2ulB+gGEHunJJnw5FW7Uhtmw7J3px0sCmgJSbw==
@@ -10093,33 +9277,14 @@ sparqlee@^3.0.0:
     sparqlalgebrajs "^4.2.0"
     uuid "^8.0.0"
 
-sparqljs@^3.1.2, sparqljs@^3.4.1, sparqljs@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.6.1.tgz#9aa6d07afbce2b95edfcd83403fac09b3ab51f73"
-  integrity sha512-4QoI3cMywOio8mtTLa3Rl85XI7UBvQRm1CbzbHEQ7C6AN6ldBFsSS96vkhcKCQKPl0eDTmCXsi+50234+1cOpA==
-  dependencies:
-    rdf-data-factory "^1.1.1"
-
-sparqljs@^3.6.2, sparqljs@^3.7.1:
+sparqljs@^3.1.2, sparqljs@^3.4.1, sparqljs@^3.6.2, sparqljs@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.1.tgz#5d121895d491d50214f2e38f2885a3a935b6c093"
   integrity sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==
   dependencies:
     rdf-data-factory "^1.1.2"
 
-sparqljson-parse@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-2.1.2.tgz#e727724ca8c9e6bc979f0d15c550d862f6ae3003"
-  integrity sha512-RqPeyy+RYQMeqgEsKPTY+ME5ZNXcgXJzg1v0o+tROiTntS9CwUW8mAY3wsx6seSvW3LVyNDEtsqOxnAokoGXOA==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@types/readable-stream" "^2.3.13"
-    buffer "^6.0.3"
-    jsonparse "^1.3.1"
-    rdf-data-factory "^1.1.0"
-    readable-stream "^4.0.0"
-
-sparqljson-parse@^2.2.0:
+sparqljson-parse@^2.0.0, sparqljson-parse@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz#58c788e896f7d2c0d3079452d8812943049d4a7e"
   integrity sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==
@@ -10151,9 +9316,9 @@ sparqlxml-parse@^2.1.1:
     readable-stream "^4.0.0"
 
 spdx-correct@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
-  integrity sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
+  integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
@@ -10172,9 +9337,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.12"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz#69077835abe2710b65f03969898b6637b505a779"
-  integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz#7189a474c46f8d47c7b0da4b987bb45e908bd2d5"
+  integrity sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==
 
 split-ca@^1.0.1:
   version "1.0.1"
@@ -10201,15 +9366,15 @@ sprintf-js@~1.0.2:
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 ssh2@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-1.11.0.tgz#ce60186216971e12f6deb553dcf82322498fe2e4"
-  integrity sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-1.14.0.tgz#8f68440e1b768b66942c9e4e4620b2725b3555bb"
+  integrity sha512-AqzD1UCqit8tbOKoj6ztDDi1ffJZ2rV2SwlgrVVrHPkV5vWqGJOVp5pmtj18PunkPJAuKQsnInyKV+/Nb2bUnA==
   dependencies:
-    asn1 "^0.2.4"
+    asn1 "^0.2.6"
     bcrypt-pbkdf "^1.0.2"
   optionalDependencies:
-    cpu-features "~0.0.4"
-    nan "^2.16.0"
+    cpu-features "~0.0.8"
+    nan "^2.17.0"
 
 sshpk@^1.7.0:
   version "1.17.0"
@@ -10269,9 +9434,9 @@ statuses@2.0.1:
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
 stream-to-string@^1.1.0, stream-to-string@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/stream-to-string/-/stream-to-string-1.2.0.tgz#3ca506a097ecbf78b0e0aee0b6fa5c4565412a15"
-  integrity sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/stream-to-string/-/stream-to-string-1.2.1.tgz#15cb325d88b33cc62accb032c7093f85eb785db2"
+  integrity sha512-WsvTDNF8UYs369Yko3pcdTducQtYpzEZeOV7cTuReyFvOoA9S/DLJ6sYK+xPafSPHhUMpaxiljKYnT6JSFztIA==
   dependencies:
     promise-polyfill "^1.1.6"
 
@@ -10293,16 +9458,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-string-width@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10311,21 +9467,39 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string.prototype.matchall@^4.0.5, string.prototype.matchall@^4.0.6:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
-  integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
+string.prototype.matchall@^4.0.7:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.9.tgz#148779de0f75d36b13b15885fec5cadde994520d"
+  integrity sha512-6i5hL3MqG/K2G43mWXWgP+qizFW/QH/7kCNN13JrJS5q48FN5IKksLDscexKP3dnmB6cdm9jlNgAsWNLpSykmA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    get-intrinsic "^1.2.1"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.5"
+    regexp.prototype.flags "^1.5.0"
+    side-channel "^1.0.4"
+
+string.prototype.trim@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz#a68352740859f6893f14ce3ef1bb3037f7a90533"
+  integrity sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
-    get-intrinsic "^1.1.3"
-    has-symbols "^1.0.3"
-    internal-slot "^1.0.3"
-    regexp.prototype.flags "^1.4.3"
-    side-channel "^1.0.4"
 
-string.prototype.trimend@^1.0.5:
+string.prototype.trimend@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
   integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
@@ -10334,7 +9508,7 @@ string.prototype.trimend@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string.prototype.trimstart@^1.0.5:
+string.prototype.trimstart@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
   integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==
@@ -10343,7 +9517,7 @@ string.prototype.trimstart@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string_decoder@^1.1.1:
+string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
@@ -10357,19 +9531,19 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@^5.1.0, strip-ansi@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
+  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -10398,7 +9572,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -10434,16 +9608,6 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-
-table@^5.2.3:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
-  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
-  dependencies:
-    ajv "^6.10.2"
-    lodash "^4.17.14"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
 
 table@^6.0.9:
   version "6.8.1"
@@ -10524,18 +9688,6 @@ through2@^4.0.0:
   dependencies:
     readable-stream "3"
 
-through@^2.3.6:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
-
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
-
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -10584,9 +9736,9 @@ toidentifier@1.0.1:
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tough-cookie@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
-  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
   dependencies:
     psl "^1.1.33"
     punycode "^2.1.1"
@@ -10624,9 +9776,9 @@ trim-newlines@^3.0.0:
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 triple-beam@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
-  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
+  integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
 
 ts-guards@^0.5.1:
   version "0.5.1"
@@ -10649,17 +9801,17 @@ ts-jest@^26.4.3:
     semver "7.x"
     yargs-parser "20.x"
 
-tsconfig-paths@^3.12.0, tsconfig-paths@^3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
-  integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
+tsconfig-paths@^3.14.1:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
+  integrity sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==
   dependencies:
     "@types/json5" "^0.0.29"
-    json5 "^1.0.1"
+    json5 "^1.0.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -10669,7 +9821,7 @@ tsscmp@1.0.6:
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
   integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
-tsutils@^3.17.1, tsutils@^3.21.0:
+tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
@@ -10694,13 +9846,6 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
-
-type-check@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  integrity sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
-  dependencies:
-    prelude-ls "~1.1.2"
 
 type-detect@4.0.8:
   version "4.0.8"
@@ -10740,6 +9885,45 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typed-array-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz#18de3e7ed7974b0a729d3feecb94338d1472cd60"
+  integrity sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.1"
+    is-typed-array "^1.1.10"
+
+typed-array-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz#d787a24a995711611fb2b87a4052799517b230d0"
+  integrity sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==
+  dependencies:
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    has-proto "^1.0.1"
+    is-typed-array "^1.1.10"
+
+typed-array-byte-offset@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz#cbbe89b51fdef9cd6aaf07ad4707340abbc4ea0b"
+  integrity sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    has-proto "^1.0.1"
+    is-typed-array "^1.1.10"
+
+typed-array-length@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
+  integrity sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==
+  dependencies:
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    is-typed-array "^1.1.9"
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -10747,15 +9931,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.6.3:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
-
 typescript@^4.6.4:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uglify-js@^3.1.4:
   version "3.17.4"
@@ -10806,9 +9985,9 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 unzipper@^0.10.11:
-  version "0.10.11"
-  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.11.tgz#0b4991446472cbdb92ee7403909f26c2419c782e"
-  integrity sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==
+  version "0.10.14"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.14.tgz#d2b33c977714da0fbc0f82774ad35470a7c962b1"
+  integrity sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==
   dependencies:
     big-integer "^1.6.17"
     binary "~0.3.0"
@@ -10821,10 +10000,10 @@ unzipper@^0.10.11:
     readable-stream "~2.3.6"
     setimmediate "~1.0.4"
 
-update-browserslist-db@^1.0.9:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
-  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
+update-browserslist-db@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
+  integrity sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
@@ -10885,9 +10064,9 @@ uuid@^9.0.0:
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz#cdada8bec61e15865f05d097c5f4fd30e94dc128"
+  integrity sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
 
 v8-to-istanbul@^7.0.0:
   version "7.1.2"
@@ -11012,14 +10191,25 @@ which-boxed-primitive@^1.0.2:
     is-symbol "^1.0.3"
 
 which-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
+  integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
 
 which-pm-runs@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.1.0.tgz#35ccf7b1a0fce87bd8b92a478c9d045785d3bf35"
   integrity sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==
+
+which-typed-array@^1.1.10, which-typed-array@^1.1.11:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
+  integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 which@^1.2.9:
   version "1.3.1"
@@ -11044,24 +10234,7 @@ winston-transport@^4.5.0:
     readable-stream "^3.6.0"
     triple-beam "^1.3.0"
 
-winston@^3.3.3:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.8.2.tgz#56e16b34022eb4cff2638196d9646d7430fdad50"
-  integrity sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==
-  dependencies:
-    "@colors/colors" "1.5.0"
-    "@dabh/diagnostics" "^2.0.2"
-    async "^3.2.3"
-    is-stream "^2.0.0"
-    logform "^2.4.0"
-    one-time "^1.0.0"
-    readable-stream "^3.4.0"
-    safe-stable-stringify "^2.3.1"
-    stack-trace "0.0.x"
-    triple-beam "^1.3.0"
-    winston-transport "^4.5.0"
-
-winston@^3.8.2:
+winston@^3.3.3, winston@^3.8.2:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.10.0.tgz#d033cb7bd3ced026fed13bf9d92c55b903116803"
   integrity sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==
@@ -11078,15 +10251,19 @@ winston@^3.8.2:
     triple-beam "^1.3.0"
     winston-transport "^4.5.0"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
 wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
@@ -11097,14 +10274,14 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
   dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -11120,13 +10297,6 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
-
-write@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
-  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  dependencies:
-    mkdirp "^0.5.1"
 
 ws@^7.4.6:
   version "7.5.9"
@@ -11162,6 +10332,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"
@@ -11221,20 +10396,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.6.2:
-  version "17.6.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
-  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
-
-yargs@^17.7.1:
+yargs@^17.6.2, yargs@^17.7.1:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bergos/jsonparse@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@bergos/jsonparse/-/jsonparse-1.4.1.tgz#560e7125f65d0ad6b96dfe1c0d5da3115b9f8c59"
+  integrity sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==
+  dependencies:
+    buffer "^6.0.3"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -333,6 +340,14 @@
     "@comunica/core" "^2.6.0"
     "@comunica/types" "^2.6.0"
 
+"@comunica/actor-abstract-mediatyped@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.8.2.tgz#18265089afb5c0da7253a3476fd59d3193d98382"
+  integrity sha512-WXkvFfDjWSJw1KRknNtqOIC9cLc9Jg24ItHfpqQ9p4slq/448j2kOZEaxi0PhfDbw2wfUuF92nyo7tuajzSnSg==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
 "@comunica/actor-abstract-parse@^2.5.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.5.1.tgz#6a2d9f23549e86c9f76acc92795235433ac3cbfa"
@@ -341,39 +356,55 @@
     "@comunica/core" "^2.5.1"
     readable-stream "^4.2.0"
 
-"@comunica/actor-abstract-path@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-path/-/actor-abstract-path-2.5.1.tgz#a6ac54d21b501d44d64ca248623d849eb62bc340"
-  integrity sha512-cgScbMCc+iWaJ1+9zb6jHC5/JOt8eSKar+TE37UMfK9+wkrI/4WoZOKI0fAD58lSs5D6n9rZLIBUpTQSGmOV9Q==
+"@comunica/actor-abstract-parse@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.8.2.tgz#d018d22c38586661bb2375149752d67cb6e38187"
+  integrity sha512-ruFphf3Xil+oZGUJw2N0UF/E/Jo7v+mCER8RUiTJi/94etZSa7jEZ9wCZQNfZmmQy8X4cTJkls4ItSxyJ0yu2w==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/core" "^2.8.2"
+    readable-stream "^4.2.0"
+
+"@comunica/actor-abstract-path@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-path/-/actor-abstract-path-2.8.2.tgz#5de04c8def8bdd3f91bb9a652996d36de64d8f53"
+  integrity sha512-d1VCl06T7JYDWTMYFNBNgUPJIrFaONPyESA9mQiWQzPiaJYXsV+TGe1l5emovJmvTolMNEGbQTt3UKc6hYIvnA==
+  dependencies:
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-context-preprocess-source-to-destination@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-2.5.1.tgz#e52b8d39b45cd35ad4f2bdc878c75e1d96cc1c55"
-  integrity sha512-GmNUsCAFBBjrvYLQmSJyC6pGqggtXW+7WpqzGxoqIKleDCnhJe6RaOztD1LfOyQFt84kTq5bmWtF/C4elNCLMg==
+"@comunica/actor-context-preprocess-source-to-destination@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-2.8.2.tgz#bf93e6062963369e569135c50c61fd7140fc17a4"
+  integrity sha512-m/VAc8dXNuz2thZ7Ey7lnPlHfY5y68b6YNdTsGLX8XRJGT7v8xb8gL7p46KKSj6N+ywQg3pdExADUlmQFJGCuw==
   dependencies:
-    "@comunica/bus-context-preprocess" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-context-preprocess" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/actor-dereference-fallback@^2.0.2", "@comunica/actor-dereference-fallback@^2.5.1":
+"@comunica/actor-dereference-fallback@^2.0.2":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.5.1.tgz#03301abb3aa56387f1b2f86349cc75a308a201cb"
   integrity sha512-Yn3NFS73LV62QLYYzdGxTAROHr319D2RmNwXxkkz98oVFVkoWsWU+ojIA4n8yjceuHu0jXP5C0NNJIou+dR2lw==
   dependencies:
     "@comunica/bus-dereference" "^2.5.1"
     "@comunica/core" "^2.5.1"
+
+"@comunica/actor-dereference-fallback@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.8.2.tgz#8c128db4722b39918fe90dfad6d13b1a40bc9ec5"
+  integrity sha512-XDEUN54hyX/phxzJQFbkemoO92CIwa30YHys6bQV1mtfy8oINqfpabFXNr9VSsMO3CpQE5FsfJfFWUD8vdcSVw==
+  dependencies:
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
 "@comunica/actor-dereference-file@^2.0.2":
   version "2.5.1"
@@ -383,7 +414,7 @@
     "@comunica/bus-dereference" "^2.5.1"
     "@comunica/core" "^2.5.1"
 
-"@comunica/actor-dereference-http@^2.0.2", "@comunica/actor-dereference-http@^2.5.1":
+"@comunica/actor-dereference-http@^2.0.2":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-http/-/actor-dereference-http-2.5.1.tgz#83c0c2b9a15de1431308344b1092bb7e9fc1b16b"
   integrity sha512-Vy9IyaNgygp5qFB14/FV6bt77JQJgOfEfMopyC2f8KcMWmFHdbuRPVCv83kme4wouB6d6L0mCvQ2yT6uWQf8qQ==
@@ -395,27 +426,39 @@
     relative-to-absolute-iri "^1.0.7"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-dereference-rdf-parse@^2.0.2", "@comunica/actor-dereference-rdf-parse@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.5.1.tgz#4ea89801b553cd9f1bc39ed41c0f46c3880ee0a8"
-  integrity sha512-24u/lt1yJcwAijwJSfOI19L6ZAMmctgyJFrZRjvwPG+g3kl9Eyqw0WdWhKijOj+/bS3nSaQGKL7MlUkYM6VZfQ==
+"@comunica/actor-dereference-http@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-http/-/actor-dereference-http-2.8.2.tgz#90bea997db993d1223170b82043bef85d12add6f"
+  integrity sha512-3yaGR+3o+t1avUYmgeZzvYqQvQ1fMGn2Ji0FrYuEwbx9Wty0kCr7jRjDYB4VyagwPx6lzQy0RVoNb6LbUNSiXA==
   dependencies:
-    "@comunica/bus-dereference" "^2.5.1"
-    "@comunica/bus-dereference-rdf" "^2.5.1"
-    "@comunica/bus-rdf-parse" "^2.5.1"
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    cross-fetch "^4.0.0"
+    relative-to-absolute-iri "^1.0.7"
+    stream-to-string "^1.2.0"
 
-"@comunica/actor-hash-bindings-sha1@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-bindings-sha1/-/actor-hash-bindings-sha1-2.5.1.tgz#90ed2c4e09258a2079977c1f123dd2a952287f33"
-  integrity sha512-S0RYCZu2bKsZx4ktRZlSy3es2hJ5QtDRLec4RTZEjKlitCyanJ+Y2glK+up8Y1PfonjrWWbmNEQkMa5zC6W8aA==
+"@comunica/actor-dereference-rdf-parse@^2.6.0", "@comunica/actor-dereference-rdf-parse@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.8.2.tgz#8279645060aef6af22893fdbd7c67c122921fd39"
+  integrity sha512-/jMUiTUuizIF5fCrZtbCYv4HWTU762TsYEIf6slmr8DyRum8DKzSL/ototK50bkush9xltFL/Kmsvhp0fBBFVQ==
   dependencies:
-    "@comunica/bus-hash-bindings" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    canonicalize "^1.0.8"
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/bus-dereference-rdf" "^2.8.2"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+
+"@comunica/actor-hash-bindings-sha1@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-bindings-sha1/-/actor-hash-bindings-sha1-2.8.2.tgz#3540d8a4b1216d25e95484dfc31a60352c015df1"
+  integrity sha512-JwBY+edoVkTleEMhQjws/ojOSTtVvO1PY0jTfBHh8V5d8c5V6XodJs7AshMbnss3/qu/6T11aIUSyyBDepkyJA==
+  dependencies:
+    "@comunica/bus-hash-bindings" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    canonicalize "^2.0.0"
     hash.js "^1.1.7"
     rdf-string "^1.6.1"
 
-"@comunica/actor-http-fetch@^2.0.1", "@comunica/actor-http-fetch@^2.5.1":
+"@comunica/actor-http-fetch@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-2.5.1.tgz#c49e265bfc46e9d36ea8db9bdd53210f3ebf7ee5"
   integrity sha512-2E25qKw2+16iWOHfaaGkbzv14owMwN3UGWURPaLyFIOa8S6xkjU/8CMWRjaGibee2KOC8TKUioeQ+YJCweIC/w==
@@ -426,7 +469,18 @@
     abort-controller "^3.0.0"
     cross-fetch "^3.1.5"
 
-"@comunica/actor-http-proxy@^2.0.1", "@comunica/actor-http-proxy@^2.5.1":
+"@comunica/actor-http-fetch@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-2.8.2.tgz#a9fd75cdcb684688394bb7fe35c99749b959732b"
+  integrity sha512-XKPWbWihnBGPn3fnf7kxq2wVENDbCtTOl+9hFgsspoh1ew8fc0Fri85iE5dE5Z82s5PfW/oxQBFZVeiwKHwAZw==
+  dependencies:
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/mediatortype-time" "^2.8.2"
+    abort-controller "^3.0.0"
+    cross-fetch "^4.0.0"
+
+"@comunica/actor-http-proxy@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-2.5.1.tgz#5139f23c087b768022f414303b49a62265eadb1d"
   integrity sha512-VlBxLWgg0wC+xl3Ut8ZNSADHJZR472+VB8YI+MkQhU2uUvvt5eHUzaEu0QDY7K9sjEfbw+qh6plXCum1REOYhg==
@@ -436,918 +490,972 @@
     "@comunica/mediatortype-time" "^2.5.1"
     "@comunica/types" "^2.5.1"
 
-"@comunica/actor-http-wayback@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-http-wayback/-/actor-http-wayback-2.5.1.tgz#2c2de5bbd5720fa724abca5b9120c5c872f35dde"
-  integrity sha512-HOLBhbYAugoIL9QUAPyvPSQJp3OeGPg5ZEZ+WC1lhMqd7Qsj6zlEr+cV+gs/Dwlpo11OxLxseyqVM9BNmbkQgg==
+"@comunica/actor-http-proxy@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-2.8.2.tgz#aec3147132934649c969c7e586db390014e66b35"
+  integrity sha512-OOFWfWVdi5mpRRgrNIqFx+C1wv3ulcDaBYojzbQdktwl6Vsz79Hlh3EHsgyTVxKHLjuhGeb/3aNbj2cFMVlF+A==
   dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    cross-fetch "^3.1.5"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/mediatortype-time" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/actor-http-wayback@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-wayback/-/actor-http-wayback-2.8.2.tgz#37c6ea96fc71f15133dd810e1d2b78ff25241e53"
+  integrity sha512-rTb0srYPLAv2jGLXEyT8bFbqiasUSpQiC/Mu3eezJQ4lXLe30gmiaiw+eBiHmNeX1TAp4By2IAZbxgB/+Z3lCw==
+  dependencies:
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    cross-fetch "^4.0.0"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-init-query@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-init-query/-/actor-init-query-2.5.1.tgz#c77906a028b5ffafb3f5bcc19d0a7c6ab890c523"
-  integrity sha512-tsa0S9Qf62mZQ7Yn3ZIfxd8ckTUT3BHiWC8stmG2aEnSfQEABiEkCezu+1EEO/T08ETYOK1ohRyA6yySsB58Wg==
+"@comunica/actor-init-query@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-init-query/-/actor-init-query-2.8.2.tgz#960ef9b28b5401b65ac0e4c5c6f6f2dcd8c0dd42"
+  integrity sha512-1px7oiblcR4S7P2YCcXhAOI4DzfhSJXjj+pN5zmsa6Yb2RjDLeeiQIUstlzmUVC/kl5lFm6Zf50ohM5Ws/+CQA==
   dependencies:
-    "@comunica/actor-http-proxy" "^2.5.1"
-    "@comunica/bus-context-preprocess" "^2.5.1"
-    "@comunica/bus-http-invalidate" "^2.5.1"
-    "@comunica/bus-init" "^2.5.1"
-    "@comunica/bus-optimize-query-operation" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-query-parse" "^2.5.1"
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/logger-pretty" "^2.5.1"
-    "@comunica/runner" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/actor-http-proxy" "^2.8.2"
+    "@comunica/bus-context-preprocess" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-init" "^2.8.2"
+    "@comunica/bus-optimize-query-operation" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-query-parse" "^2.8.2"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/logger-pretty" "^2.8.2"
+    "@comunica/runner" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     "@types/yargs" "^17.0.13"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     negotiate "^1.0.1"
     rdf-quad "^1.5.0"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
     streamify-string "^1.0.1"
     yargs "^17.6.2"
   optionalDependencies:
     process "^0.11.10"
 
-"@comunica/actor-optimize-query-operation-bgp-to-join@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.5.1.tgz#fc4c7938dca28e29e57e62943f7fb434b9af7aa2"
-  integrity sha512-PEt32DHRzxHKJk+h/RF35t8/Jat0FlxwLOQMAjuyJPeg9IcFTovIEbYySTGZ7J7QIt5kJD2xWovE11nWfUg+EQ==
+"@comunica/actor-optimize-query-operation-bgp-to-join@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.8.2.tgz#f21281f1d9b9282ae56b78b5ae289fcfec54c272"
+  integrity sha512-ECTnXBeDc3d2mgTYobuPGpxh0jRyALVsju4gcwpu50IADcQWmoZ//fvscIsYfnly35MLL3QpxNOO4FeaLtB6yw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-optimize-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-optimize-query-operation-join-bgp@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-2.5.1.tgz#8fcb10bd356ecdcbb031ccc4d1f8d823c7404e5b"
-  integrity sha512-Ao1c+deBJs3bF3sPV8gt95sLeHFJ8zD+UgOB7E1Q/coWPePmPHXgtjVGblfBtK7+zuuEk/bf9sgoEJ8iu6HPlQ==
+"@comunica/actor-optimize-query-operation-join-bgp@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-2.8.2.tgz#de954c32e40f699b2c9ef53be4f6b5b9b1a4396c"
+  integrity sha512-hDnimckCwvDOFTCeqQR+iR+seDoJRvl53MgiXxlywmspJNpCKM9azTE2Q4Xii1VmijsZDCEt55yb/9nQClNrTw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-optimize-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-optimize-query-operation-join-connected@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-2.5.1.tgz#e5b6563ec8e812d54bdbec58df621f910f65c0f5"
-  integrity sha512-6CEFcf1+L1t+w28TuyO5dgxlU07j53f3h235as5BqIbUzK16yjfERrqqvKSjdaHlj3XqWM8T+znmidsmnzf+pg==
+"@comunica/actor-optimize-query-operation-join-connected@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-2.8.2.tgz#facc3cc231093a1a0fb7489a2d0c9c45588129de"
+  integrity sha512-KEjOHKS4M0LIuJZHRWSED1vKc7rEzmJ+T1ByqyTDvURfnUEl0I6KOcfYfpiWELfSliOSFBLqirwlrJvSaYN8Ug==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-optimize-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-ask@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-2.5.1.tgz#8f5a8f26650029a3b27b701c3accc164246190d0"
-  integrity sha512-2Xsvt6p9YfqTQIY4LJ7mdrqRPf7ocb6N/g/S+Lj9w4mje8d4Yd+Hft5HgPQUsMk70SHUb8tTlvSsraPzXERphw==
+"@comunica/actor-query-operation-ask@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-2.8.2.tgz#834cdff1612020a46b14aed9c54b0c325306d3a8"
+  integrity sha512-6yZzrWZI0ie7jLZczEzMEs+bEeW7DdneATCutXyaYntPLepEMpQ8LjopZ0yeZdZwrRPWK29FJhoBeORvpeSTbw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-bgp-join@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.5.1.tgz#cc7e92732fc6a0a84b536dca80b888d6fb06fd5d"
-  integrity sha512-DNWM6ZB1I+0EwagGuM0LsQj2rV+g7/UPGk/UGPeJKtEZARr7Tn0rsmWZxZsYL9LvQl2bM9zs166DrlLyIL54Xg==
+"@comunica/actor-query-operation-bgp-join@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.8.2.tgz#57ee7d72a819fdb7c3db7f407065b231835e7db7"
+  integrity sha512-zbsBwMiJV+I1ZsHnpc5fP6IWZTzwGQ5kd0JhtMN/pY3VLvd655gQEGplMG1EkyOsPEF3QvtSmROHPe5ONkuE5g==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-construct@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-2.5.1.tgz#a70cfc003a0084399aa4f780c91172d89f0354a6"
-  integrity sha512-470PGbDK/8iqPR+R6cmzBRD1zaCfSoKcp1fnVEItJI2Y4uElT2ckjR57M4rXcFxArHtKcBohkQ2dGf3VRZfpWQ==
+"@comunica/actor-query-operation-construct@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-2.8.2.tgz#ccc211631d38e026fd4c697d11362a42da31512f"
+  integrity sha512-/TkTk1RPf6QrDVShP5QHr83dpEBPA7yh611rWrL+NKRJhd5tJVdaWH7adAcKZBCXt+w5a458GdbRMF+W4FPwuQ==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-describe-subject@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-2.5.1.tgz#0df278d14b28186f602f7677b14731f7f8eaa8ce"
-  integrity sha512-SPUKYJqhltUYWXf7FrbOJQV7nBOETDrGHc7kE12deD3jxOch+btbfjOKD9Wl9/zyU29/t7QF7n+5BHESvpC/kw==
+"@comunica/actor-query-operation-describe-subject@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-2.8.2.tgz#ab7aa3ff437883d1b717c6fdf834e997a9f30d34"
+  integrity sha512-DR0fCKXXPEt3xQF7A4jiPZ2rBgdOxOundGMxNKj5ns/9DWUra1i5s/uz2GE/fpon8kCfvabLwQApfFPZvkb/qw==
   dependencies:
-    "@comunica/actor-query-operation-union" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
+    "@comunica/actor-query-operation-union" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-distinct-hash@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-2.5.1.tgz#be446655e68c7e3a0a4b3819277e4698d79b28e4"
-  integrity sha512-hi3Wq8GF3NT7F5fojqhJn+EfnZ7aJ6TTc11ZdQVcLY2fXNPAR4O/jkusIpXk8IoH/6UJEW9ZqM7ZnhHd5LzN/Q==
+"@comunica/actor-query-operation-distinct-hash@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-2.8.2.tgz#3da58214a8c2533ed0d9023751a1b30b4b3d0ab0"
+  integrity sha512-9qoFXs81ttTb4W4jBmY4P3VCm5tF9+EDgDwGST9GKo+n2fz1iBid/8xpVBO1SHxuhmK0Cz3we5FJUBjMT43UKQ==
   dependencies:
-    "@comunica/bus-hash-bindings" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-hash-bindings" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-extend@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-2.5.1.tgz#35317c1280be5ea849c2a9a8ee1952ccf0bb996e"
-  integrity sha512-3ahNJuYS03STeqzmRVCb4UXOvI62KJdCBjrYpvMgvyan+8qOgVsr7IJz9OY4dHAS+8xEcoxr2SubibsR4TeMVQ==
+"@comunica/actor-query-operation-extend@^2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-2.8.3.tgz#706aa4adc834266bd27c95f9424b37161e56ead5"
+  integrity sha512-uWiS151ujGNKXLGCr5LBYM3+9V8Snj4jCXWDUm5dbrwGtf3SpfnDFUMGEGTb8b5DAV11cniHoAmW4mZekLEmSA==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.1.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+    sparqlee "^3.0.0"
 
-"@comunica/actor-query-operation-filter-sparqlee@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-2.5.1.tgz#349ad5cd8f2f14563dc3cfbdc25f14bd64972e95"
-  integrity sha512-JIiavjAQBGjVBn60b6DRQceZoxIP7BrAP0Fh2I9Ngzl0uydtUNC3gMHcwwR1CwV6G+y50KP0/OSx9SRNSDWkjQ==
+"@comunica/actor-query-operation-filter-sparqlee@^2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-2.8.3.tgz#3c092fef02c6636f3bedaad7e876e37e47038b1a"
+  integrity sha512-S0dmsbkm/VI68th2/0UMd7trtRvKRCx4sRqOqiGav3HaqKAjlsIi4ko9vhxwM7EkthCPteVdmmuK4fKO159n3g==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.1.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+    sparqlee "^3.0.0"
 
-"@comunica/actor-query-operation-from-quad@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-2.5.1.tgz#521427cf8b8709675988a74b4974515e42cba0f1"
-  integrity sha512-i5NpTFaaRbjmU3+IToPY29ROB5B+0aPJpn2xIdenEbWZFt2QvKhydqR6HK1I4VHsG8N2k8z+j0EB5QC8KffmJQ==
+"@comunica/actor-query-operation-from-quad@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-2.8.2.tgz#fb898700027cfcb3a2b46f483cde5115e13fd7b8"
+  integrity sha512-4TYrvE5b7Es1nOIZyZSgj7U+SHyBXudBEQPlN5JaUONMKsp4WqqDjCa/e0KoH1MMcZspJ+xACeWokdaBhb2mRA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-group@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-group/-/actor-query-operation-group-2.5.1.tgz#e782a262f56aa5825e2d2ce3bfff49562997b703"
-  integrity sha512-hMQQhIbW9ME/H1t9GiZv+2GTHMH6syFFRFCAu6U4KpzPTE9zTLiMo3WLo9M7oJ8zUkbciB5OCP1VKztO/BzupA==
+"@comunica/actor-query-operation-group@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-group/-/actor-query-operation-group-2.8.2.tgz#4492beddef56ff7c9acdef3669ea7a976ce1b949"
+  integrity sha512-nGMxuclLphGa00BI3sXu8LjxcISjCSuHKG4htSNvhp5aJqKNtmEyc3a/egSVG5X/2qtDxMUyIajFA1rBgmpxHQ==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-hash-bindings" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-hash-bindings" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.1.0"
+    sparqlalgebrajs "^4.2.0"
+    sparqlee "^3.0.0"
 
-"@comunica/actor-query-operation-join@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-join/-/actor-query-operation-join-2.5.1.tgz#b92a7cde678efc7bfa1feaf20858e0f3e224e92c"
-  integrity sha512-an4INEGYjYDaTz+QhN747GFWthi5Vl0uGhuAGxOCWX8tkmXItAWnxnIxqbE6lrywrMAsSKTefdEZTAuBGEbi7g==
+"@comunica/actor-query-operation-join@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-join/-/actor-query-operation-join-2.8.2.tgz#1dcff67b18c7314f63b707c6098f49a3022c6760"
+  integrity sha512-ldabBzZe5C247R4f00h44EvCz9vi9nqNT3BrEboTlQT3WJWtfLGFa6Uag2SYvGdg2LF5KtQfPUdG0+ueGIideQ==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-leftjoin@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-2.5.1.tgz#60cdc8b8c7af33f54a9bfe78500df83bc2430313"
-  integrity sha512-Zj34DosMbWJw/I0hlRI3MMuy6FCXf98jW2RMA3ExiAGw9ZBhc6bA1BZ828Oz30/8PDduhaR4aAJA9R4gXJc4sw==
+"@comunica/actor-query-operation-leftjoin@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-2.8.2.tgz#499cb9d1ef97a291c6cfe7550c3b9b970c24deb2"
+  integrity sha512-bHg5LndIRWGwMtRp9/neXkkEa2Q8YQwoKJ/icE2ujncjrdir+1MXw0ti41FXWtOZL06iPkPkkf0/myukojWV5A==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.1.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+    sparqlee "^3.0.0"
 
-"@comunica/actor-query-operation-minus@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-2.5.1.tgz#2322f3dbd416c4ad67e200315c8aaeba96f78df0"
-  integrity sha512-KENZnMG8QmQf2zQfb5c6BfX/jvkNf6WkmADoq3UU8kcBfGAWTl/2xBEfkvQQOapzrX14GOsMWSD2jfC1YCI4oQ==
+"@comunica/actor-query-operation-minus@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-2.8.2.tgz#cd6bf8f9c6d3891eae1b2328eae0df9b14a1cbf8"
+  integrity sha512-WBew+Z10Wg6u8Yictc1q7rg6GJz+C52AaM/RfNTdFdl5PS/GAz+iXQti07owHRaVhRRw5eV7r7cN7tdxLfw+5w==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-nop@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-2.5.1.tgz#ab9b7904f77288fe69b0afd3be50736e237a1b85"
-  integrity sha512-KzbTicBlrwJcLByO2lZ7dSMU52QUNqv2kZLE1V959znGJvyMXfN+tpJnz72U/LOrZ12H/YyU2uAPw3fvNy8skQ==
+"@comunica/actor-query-operation-nop@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-2.8.2.tgz#4f98b33c2d3536ccd2ea474e89a6f0c7a472298b"
+  integrity sha512-c328daI6fDAKvm2X4MP7N2gGNQAJPVWPzR8w7i4chzpJbvgV2kMpNlqc091yuwwcntB+OzzBQTNfTMQhWaB1sQ==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-orderby-sparqlee@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-2.5.1.tgz#c59c7b4bdf2dbd104953393fecf33275209b98d3"
-  integrity sha512-8ZDBSKL4Lcvxjl4RPCpX2yfZLTXMgF+wac9pERBeVeV9SsUm3gk1qx9rLV4nMSFEAgqXmf0bAbyfPqjgD2hTfA==
+"@comunica/actor-query-operation-orderby-sparqlee@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-2.8.2.tgz#27bf72c808c3c65c8c068850735d0e8b62aaeb3e"
+  integrity sha512-YDRAqOeEYJMYhiEZgr1pxvH2zi2SCOa1lhq2rs8s6pqiejXfIPv6kEi3uWUw5/hDM3EHLMf7MSwB3xX1X6WS4Q==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.1.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
+    sparqlee "^3.0.0"
 
-"@comunica/actor-query-operation-path-alt@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-2.5.1.tgz#9d4f29058930911d190f9414d20f196d90f21755"
-  integrity sha512-QtLgfsE3kewExaWGP8tRgLE4+UP+ht5BIRpS0hmOeZv7zWHJVIbAyIIDhxx60T300sybbXI6vDx/lsVvsXlZtw==
+"@comunica/actor-query-operation-path-alt@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-2.8.2.tgz#ed867fd2672d4b837107c175feabc373741a35b9"
+  integrity sha512-jO0RevAES//4GP8rEnqNkN1SEB/cWVU+ybQ5mF11ZbYrnzf89E+ozQgZb9v+ztNt6I56af1a2IIr+EBjMQDVww==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.5.1"
-    "@comunica/actor-query-operation-union" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.8.2"
+    "@comunica/actor-query-operation-union" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-inv@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-2.5.1.tgz#62cff6f6db8155cd9a8b5b1d1a7a59eef16e539c"
-  integrity sha512-03+2bSaXPN6Fvf/f72JnizhmeC1W1adMcqbH1I8odAvmmxbE4uoTmw/NbEEpNoj903aSL1e2oPxpwCEjcjd4Ag==
+"@comunica/actor-query-operation-path-inv@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-2.8.2.tgz#95d7202bc2e1a89637b28108c005a78dc3a960a3"
+  integrity sha512-Di/nR4SDAcAKdjOjPJLXfyv4XT0Z+eo+yQYXHROZBusU2p2YFQ2yjeDxURt1xIIiwffMYkaKNpmDcE3leDgkXw==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-link@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.5.1.tgz#51ee3bad122de8ca3f6431f61368a2c0a0bc761a"
-  integrity sha512-/B/n8/IUHlBhuN1dPwnaOEW/fsnKTwy0lfitNvsqbvByfazJADM1GmBl9U4joIrgG2xfAnHwddypQjrl/x32vw==
+"@comunica/actor-query-operation-path-link@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.8.2.tgz#1b301791d2b7ec71aab8974111911d8b0001c9ba"
+  integrity sha512-5chsX6GhZ9uZYukGsNs2FcImgwzPr3D3bDTebdTYbH8TxVsW17PfmpmCGw4pXv0sMLcOCBv6i7x+bVw1aB0keQ==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-nps@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.5.1.tgz#58994f9b1620d00b34ee15c240b6a5cde9a14f76"
-  integrity sha512-dU4Le9uxWcYd5O1j3pOmiWmDb/t8zqvPWZoL1CiGTo+c0jhMcMWCGQO5wp1K2q8LktVWRSPCJVZljqkZ0bafZQ==
+"@comunica/actor-query-operation-path-nps@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.8.2.tgz#fc7fee1103e365f5b7cf2ea1412c903dd3223997"
+  integrity sha512-6LZL2Aj1F8zjjjeW45qag+Y9iH1YixWJweQBhmx3R8LkqkSATGao/BuL4sjpLJWzudb3HzSpvTC5ZsuVnRD2Tw==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-one-or-more@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-2.5.1.tgz#f57ddbd8a5db0bf619f4a21cf220617fb87c6e8d"
-  integrity sha512-mLxTZ9QomiGTK7OONXU5ebY2nzuJBJyJDeDmnv2NdqIlc8lRir3JE0QutpbPoGOI8YgkMfd0loAzQQ78M+EeAg==
+"@comunica/actor-query-operation-path-one-or-more@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-2.8.2.tgz#552180124fbe9136ad861f1709a69cfbf4355edd"
+  integrity sha512-vlrYHIYyjLzJfxe3C00I/SWF7hB7kz0KIdyltZhFhROQdrqPkXPDdWDXz+JLyONwsEQMOAgYeHRMgr3jdJwynQ==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.5.1"
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.8.2"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-seq@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-2.5.1.tgz#2c2e1232b934e080317da50f238cbc516e1a3f8a"
-  integrity sha512-lF9dZ1I9SAnCnEAxDsSKJ3Q0eUMcUvOTjItzx7DrwvbrZUR0dOTeT16TUdZgY1F4iwNnYG0yNg9fSn4hZiEvfg==
+"@comunica/actor-query-operation-path-seq@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-2.8.2.tgz#cb41229b71fbe4e8ffb528acfc98c5f9eb39fdc6"
+  integrity sha512-/P2Dv8Ik2PXWZB5aMQ8Av5hnJMvBzDNM0M7dD/KBgCwP+LBtQEi9Y1a9xK/MdFK1hO6a6ushI7F7MT8Hoqwp1g==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-zero-or-more@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-2.5.1.tgz#427397b2f288109ac2df196c406358c052e634dc"
-  integrity sha512-usDvnCtApINUx5MM5Md42TzlVs/OlXhAEKlbobVTSNbMBcGh0NteFU39QoU7UUhTDx4qXCeR2APTebeWt9PTEA==
+"@comunica/actor-query-operation-path-zero-or-more@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-2.8.2.tgz#940441e202cc1f3f0e00bd22d5ba4a14a7b632b4"
+  integrity sha512-F7lfSJ2ItWKeyC8boXB8Nh3ABCXSbMieCb9eLdl9MOQw+/y/pumidcepH5wruqktc0FBTBAS8jRijFS8W0QQAA==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.5.1"
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
+    "@comunica/actor-abstract-path" "^2.8.2"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-zero-or-one@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-2.5.1.tgz#ce2a612694cbd197d39dcb7eb2004e4a880e33f3"
-  integrity sha512-k7OxUR5rTu5IrUwO/jQoCO95V7Ri8oHij5O7r5E1bjcsz2QghIA9nNRz6BtvfsEFj8pDMruMV8JXgg6h8WJmHw==
+"@comunica/actor-query-operation-path-zero-or-one@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-2.8.2.tgz#b274a5f0be47138b376e8e755e78270ee52437ab"
+  integrity sha512-Ws8psxUsYFIqyfZxjKRZz9UxfU1OOS86N07XPOp7IP25lDEfAIJh75sX+Z+0/oUnCBUJU0r5KlOaLJpJUVwRbw==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.5.1"
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.8.2"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-project@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-project/-/actor-query-operation-project-2.5.1.tgz#952173507219088c3de4fe54f6b130d4117216cc"
-  integrity sha512-CxjVhg/IFttxnCESbesuRKVw3MSUsYbOGOj+pZ5XXFxSnR9538Mi+Gq34RZeCIxcsOJUNs/okGvATzAB9cDQbw==
+"@comunica/actor-query-operation-project@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-project/-/actor-query-operation-project-2.8.2.tgz#96b3fa31004a17e2093086de04af8eaa4578061b"
+  integrity sha512-atp+p4Q2RlGbrG48xRrdifmgxmIop2AFIf+TM9PlbiagTCHKNLTvivg2O7kdrfxrsR/pEnD3vMTxGYhhsxniaA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/data-factory" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/data-factory" "^2.7.0"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-quadpattern@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-2.5.1.tgz#5b2af6ff9ef10ec119fb5598074501373b33c406"
-  integrity sha512-eYz54Uwcgn5w/GG2YbaWrmj9novauZ9hv0gjjl+fcrJSiUAUM457RM9DaMDnG7co3Vlonlp2UlTosNrorT1oyQ==
+"@comunica/actor-query-operation-quadpattern@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-2.8.2.tgz#785831de16c25c545f3cf67554e42e5525cc449a"
+  integrity sha512-9amnAhlp+9OoS2fRnincOXJBOl7V6jrvOuLykQJjgd3/wpyiZa/PdDfr2hzt5sIImeYNrULGLGjZOz+rQPBN2g==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-string "^1.6.3"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-reduced-hash@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-2.5.1.tgz#28ae90dea7622ef5c406baaa3c12d3094af18ede"
-  integrity sha512-U8Zw6Vpzc+cirMGOKEIY3LTHcUzaUlzQ09V6g3ZLhHaz6iC+UYoDLllf0YwuqnrL4VTxcm9iFAoMVMFqCYAwhw==
+"@comunica/actor-query-operation-reduced-hash@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-2.8.2.tgz#9e890af05cd9782929b0893841fd6b1f57624e1a"
+  integrity sha512-/OxlPet2mcYA3ELQn/6OR7SVvz1QkaJ6WX2wBFQZJ/tn605qa1siVF6U0e8F533uq9vrdKJtW7/ToWgp15Gp8Q==
   dependencies:
-    "@comunica/bus-hash-bindings" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    "@types/lru-cache" "^5.1.1"
-    lru-cache "^6.0.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-hash-bindings" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@types/lru-cache" "^7.0.0"
+    lru-cache "^10.0.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-service@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-service/-/actor-query-operation-service-2.5.1.tgz#7b96bacecfd6749320e66ef1118f3dffc1155292"
-  integrity sha512-47KYiAfdlNErUQQDXlIpXeSwBgRxhJ2f97KDlKRQFdd29tbQ0tsqqspW2Vu9JBbHHCggHKfiYbYE0T/hkpgyQA==
+"@comunica/actor-query-operation-service@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-service/-/actor-query-operation-service-2.8.2.tgz#e37313608bdef7f76b43bbe7b5142f5e1776a527"
+  integrity sha512-xrsT3eVa6PLqQyZ/r5iUa4L0eBnzHN98U0JKJL0qQSTL2kUioBJu6wO351EU/Puj1mR4FtoK4+0JGKipktqxaw==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-slice@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-2.5.1.tgz#33df56926a4049185726cb746fbae8f2b0282f78"
-  integrity sha512-1u3+C4e7DltX8OYAcqv9qzeZXA3KvtIWhLh0/5/Mj2mgd/E0RGWcvssanLl+sQX5L6qH9GGTGprvYSgP9XJnlw==
+"@comunica/actor-query-operation-slice@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-2.8.2.tgz#55bd40b9d1affbd000f0d36f7b550511635a2640"
+  integrity sha512-ZnUlZOKJUEGt39CQpQiltNF2YYihe2mNx6SOG9cwwGS9Yp0fIZkXZhIASRcO15DyHjwWf5sRoWjLTu6/mbq7dw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-sparql-endpoint@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-2.5.1.tgz#e0b3fe2c37234a51c97e1024195af961f7266ab3"
-  integrity sha512-p98KR3FnggouZTFbUpE5Ll/Hgxghf3Z4B+TurdrxlJ3kWM9lXA9JXUjWwaElBzxMfoQ9pfdnX00g2cYANzSMEg==
+"@comunica/actor-query-operation-sparql-endpoint@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-2.8.2.tgz#cfdcd4a723df8ef00da0e1ebf5388464d86e812b"
+  integrity sha512-ylxblXucIMPiSCsefF8XnAK/pkFZu/Hxrtnwp1Q2ci+kBrJm+f1sAWadTJSCa2sosnCIREy8joz4lahaGJqCbg==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/mediatortype-httprequests" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-httprequests" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    fetch-sparql-endpoint "^3.1.1"
+    asynciterator "^3.8.1"
+    fetch-sparql-endpoint "^4.0.0"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-union@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-union/-/actor-query-operation-union-2.5.1.tgz#b27cfbf5c9c868386fd1ec2553c1a1beda372839"
-  integrity sha512-n0YamV+Iuo26P18nFnaG6HSbVFMhOyLJmY13mlRxnKGKK/TS90MGc14NR+GSbnfJYPiKa1v0WvGkubf4ngoFZw==
+"@comunica/actor-query-operation-union@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-union/-/actor-query-operation-union-2.8.2.tgz#dcb6f4d30635a79a90c2e88c7fdb325e48f5b087"
+  integrity sha512-0RaKfwG98tS2ZZKgIMIC14Y43Iwosc0QhxTn2lKGcFY57wL/OYOmr2HK6r61C7efGw1HOLNLT140HQXajZYrsg==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    asynciterator "^3.8.1"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-update-add-rewrite@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-2.5.1.tgz#17e02aaa389b310f84bedfc36bfca03e0d62f7eb"
-  integrity sha512-tXpU3AvN7k7Q5I+b+nLjSieIV7QY27CX+4R78u3+Qte4p0CoYD6YMsBPPJJSrtVaLt9SIJYJUi9B/6MMJcPuZg==
+"@comunica/actor-query-operation-update-add-rewrite@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-2.8.2.tgz#af2bd79ab23e480375cb7166ac74fad073398d07"
+  integrity sha512-/0i28jX6Kt4NKys+AJWWo+CZ546aEO0wPvveLNvh4umul7EtbNLrqTStQeDkrf3P5yGqJw8aBs+70YjdYAJ0bg==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-update-clear@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-2.5.1.tgz#0057f821baf72912ab558787e270cd5e7817a15a"
-  integrity sha512-XAam1a5h7nCsLCvH1gSIWxp6pvo8PJ5t1Lik6H36m9UhDaATaf9noiSUY2pXBfTavpnqHtH7XDnT7kvU6RlqeA==
+"@comunica/actor-query-operation-update-clear@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-2.8.2.tgz#020a152819591fb806e3f035a3203b0232a129f9"
+  integrity sha512-/o87RKhOoe8KFhjezF4khv7v35mmQoSYIcBvT9baC09nnt8hHMGGnvEKH4Qq2/lqZOymABVBVreXYRfHALXFLw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    "@rdfjs/types" "*"
-    rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-compositeupdate@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-2.5.1.tgz#b69b0786a52ba865d976bf6da86f79b257cdc082"
-  integrity sha512-AyafeIH2Mdnrag1grp2WYzzkaFneCcn5uFJ0gSreWvKDoRRrjEyqhpiBC6pifAqFSHwmbzSQ1qegUtMZuhc1MQ==
-  dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-copy-rewrite@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-2.5.1.tgz#6967c5ac3ea6d0eef3b2926e612c8aece93292aa"
-  integrity sha512-gI6pLo1lYqt+dQ36AFSqSHq5lEXq1AQ7TveskLuiibHiSmNHIVh3LBVgtKqy+z8WBJ1t4rdVspNtWE5ywqrXog==
-  dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-create@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-2.5.1.tgz#b0185552b79023b9b2e6a7aa99156b57f6551460"
-  integrity sha512-AtJZk8H/4f71+YgzEPqFq+VeIk/sEVNXARuGEarN/qnpUCizkzojzczMs4XzCZTC6w8BRj9q1miJwKjDu8nynA==
-  dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-deleteinsert@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-2.5.1.tgz#868bad54179e4a1ede85cbd364f00ff539a60cf7"
-  integrity sha512-6hv8iBw8PdT3fvK0A8NmXZlDgjZvk0DPC17suaFcEZfBzHNyO6js2aGsSHCXMugAk4zhINcIXKtOYho7ClDcoA==
-  dependencies:
-    "@comunica/actor-query-operation-construct" "^2.5.1"
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-drop@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-2.5.1.tgz#a7d7ac5a9f06f18996279a73bb16f8523dec7c15"
-  integrity sha512-bpqQhzS/93VOYtDFpSMmb5IUCiBNdAQz1ZLIoKBuWD24NSuRoS12Wd6Okh9pMwSI/kjh1n5pxFax5uXWtiQp0Q==
-  dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-update-load@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-2.5.1.tgz#799ea9e5eab9083f104f7b9c8f0be55df5deed41"
-  integrity sha512-1bQe3i/vTFiQojsKVuNWcUitndJGlNiSAag9BO4U3dsCimvcv2NTrojp6cNbvCNYNFJ/YJUmfaBnoKsxCvvtgQ==
+"@comunica/actor-query-operation-update-compositeupdate@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-2.8.2.tgz#457d2b5c2abde36361930d985e6ade18964e7af8"
+  integrity sha512-eW3pHI/g8ccb/k1P5pHVU78ABmDPN6WHbBVgRnYGpMRqMxPqBR3xnZFcmwbISRrRlu3cKFjK7KwQhAK0OjHXdA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-update-copy-rewrite@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-2.8.2.tgz#e9bfcf92be2461fdf6e5fa72c12e0f27a768bbd2"
+  integrity sha512-BwCjRvETJsdsq1ebEUwtLjbKi5zIwFX9nLThQ/xozz1/qj/fy2tQKo/krmq6O34iybc5Kr49b6u+UmTwoiFwmg==
+  dependencies:
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-update-create@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-2.8.2.tgz#9a0fb6ef2d4afc493181f2604551c3f2f9c88109"
+  integrity sha512-3Cn52DSlaFx/QOoj/jO3i9x0axSrroFu3a3cNAL+4AXogQivC9XRNJ9lhmMvFu1LotmybtfnfAx/AEY7LKk3/w==
+  dependencies:
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-update-deleteinsert@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-2.8.2.tgz#a73695fd981e23831b26a90e9a9d88c0944354e6"
+  integrity sha512-jGzPtx56gU0+Nhnh9BEZ0KD4GFy5r5261xQmPTHOwQncamKWpOdDQlHkCjMe1/T0K109EkwyKHyTt5tmk5iJVQ==
+  dependencies:
+    "@comunica/actor-query-operation-construct" "^2.8.2"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-update-drop@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-2.8.2.tgz#5a07b2b3fea123471d218dabfe33acce0ff50ad0"
+  integrity sha512-YVL/c1obz9l0zDP0/gyGvmh7G7V1YqNhU2xIA5FPHyBIENliZ3YpXdTMw/KAXYg0qiQbjS5VKZc70lypZXTusw==
+  dependencies:
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-update-move-rewrite@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-2.5.1.tgz#34cd41af89f1d84c874a4d16301e66e9cfde84ba"
-  integrity sha512-g6eZzhaMsnGD3Av8QanQWiGe8eV+o/Py/zy8kHqr1a9ynKn6GIidam+RcrOk479hh9HB0zrIfNz6EW1ueXnSow==
+"@comunica/actor-query-operation-update-load@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-2.8.2.tgz#b85288d7317ee619afd032079236aedb29d0c242"
+  integrity sha512-fg8kyHl6ie2jcPImpmkHryJwhqTxy18PViyZkznoQndBLvdbkp4Nbp2MEI/w6xuE7dlgxNr6EXDgzHAQBTKufw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-values@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.5.1.tgz#d6c3e42276547402cc19ff545d7de2fae515640d"
-  integrity sha512-5lIJ5rzcLkADdK8DhdEFxcdbZuKqk8jECIyUweDoZdHv/TvwgbmyLyqJICBWl0o7T0jrtTTn/YJWBW1yOP3Qqw==
-  dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-parse-graphql@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.5.1.tgz#963ed1186fe439cfe5b5c69f185b3271ec74b342"
-  integrity sha512-AvgiJMFV9wLKODn0Hm+LSS21K/NI2G7iOmuq3owCcChgGkO8hCsjaZG4BZJ48ABVHLtgbNTDrvdUMjp40kZsDA==
+"@comunica/actor-query-operation-update-move-rewrite@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-2.8.2.tgz#4632ffb32f49fd84ea318525fed132f05d9eba69"
+  integrity sha512-SkrfiQVYKYK1zYBnKiSAL7V5App5aGvVifvw+QwQv7QJ6GXVk8s8xrVH6abBJx4aS+ugDTE0utZW2zCawfalag==
   dependencies:
-    "@comunica/bus-query-parse" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-values@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.8.2.tgz#0194b6afc42f92be7eeb5391a4275dda9aa9a4c1"
+  integrity sha512-7iABct5rUgPTUkclCV9fRL23GPdp/864ZsfDraBSXwsuHaosqNfxUcwNNENlboysanpNGn7Wtg0WEGgNChO8UA==
+  dependencies:
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    rdf-data-factory "^1.1.1"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-parse-graphql@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.8.2.tgz#926ecea49c07b43087637420d41edfdeb857d016"
+  integrity sha512-XDyGti12+Sz9iQkO1tzoM7rO4FlcTSN2S3FgheJXIb+Ebx5L9j/31xYvROvM1XIEKTWYex1F7mAOJzwVGalqLQ==
+  dependencies:
+    "@comunica/bus-query-parse" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     graphql-to-sparql "^3.0.1"
 
-"@comunica/actor-query-parse-sparql@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-2.5.1.tgz#6cb9cb29f457eb4196daf27dedbddc0a046bc8a1"
-  integrity sha512-OG8VCR7tVHxaVFZOW+lqih9RtpSnn6tXlkEZIIJyPkTYEjLcCzFcE0+S4O7HuKfDvr6mj41lIUwRxjVnCPf/1w==
+"@comunica/actor-query-parse-sparql@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-2.8.2.tgz#a123ab23ff6addc13bb6987448f1ea8e863c27af"
+  integrity sha512-qH2fVHTX93UwtIeQKL95G/dWsLD3ThMA683hbfv7uZZwQv+SEE0MvJKcz+jcZlqtt5NWlIPPKz7TM/vL2Cf+Bg==
   dependencies:
-    "@comunica/bus-query-parse" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-query-parse" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@types/sparqljs" "^3.1.3"
-    sparqlalgebrajs "^4.0.5"
-    sparqljs "^3.6.1"
+    sparqlalgebrajs "^4.2.0"
+    sparqljs "^3.7.1"
 
-"@comunica/actor-query-result-serialize-json@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.5.1.tgz#719a6d46afb0eb87c71106b196161ad07292974d"
-  integrity sha512-MFBfQlBSEAW51LN4jZN9XRyGLtn4QFlI8w+juh5RrH9/iyKmITv7GsKseUYRjFsIIcLI15G92ttugbZD89e53g==
+"@comunica/actor-query-result-serialize-json@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.8.2.tgz#9e395999b1c1813c48c07b5f0ebb6808fcaa398a"
+  integrity sha512-NFPEFSibNGAnQbbyY2xjwauCq+DpvakMsDZItIWDKtQ78G9oYUc3u9vsR19sfkBFhNrVUeN/n697QLISRiOdYg==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     rdf-string "^1.6.1"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-rdf@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-2.5.1.tgz#5bf32740534ee7ea48b64eea54ba7fb797c1fa53"
-  integrity sha512-pI499HkLrkn59QzVOEIz5JYZ0rkIy5aqJ/tFrNXeb8ip/ntOXZbUAQjiREZ+wpgP8vVHIjX5eBCKN1LQrPhM+Q==
+"@comunica/actor-query-result-serialize-rdf@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-2.8.2.tgz#f94a9a3cfc3ace07fa9661b9db453a533562baad"
+  integrity sha512-mhhTW6ksmj5MYxaNMAEarsP3sFlCJ3qci8hgqAIW/nr8aXsZua+6xIcgyJb42Go3UhOTCJYwyQJCXAPm8s6d5g==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/bus-rdf-serialize" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/actor-query-result-serialize-simple@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.5.1.tgz#61b9fd7d26dfd8b531a59b9fae55bb87ad4bad1e"
-  integrity sha512-lt+NECnauuUsvy21/6YkL6+00NztYPjZBUz8OtMjtPlkbJjU8gZ8SD7hRTbRc+ApVUKn118z02/Zh3h9AEB3rw==
+"@comunica/actor-query-result-serialize-simple@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.8.2.tgz#66321fd65a3f9e17fbeb3985a3f5d205b421aa3a"
+  integrity sha512-EIzCuH7iOkKT2etXcW2nV7UoX6LBLISsXksGb5YnCewS6LrTjzud9ZjBANjdAZZGneHkjp/vuS3Inkx6jJjLIQ==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    rdf-string "^1.6.3"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-sparql-csv@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-2.5.1.tgz#d69adc68278f9958fa4c0ba7c729a02023d2ef16"
-  integrity sha512-16Op+6bk8aZNRLkM1cni+91PWAdTV0gbJOpjiBaWOlMFUzCaoBus2OGoQYwP398yBWmBm2ui1UkFhFqNq6Pd+g==
+"@comunica/actor-query-result-serialize-sparql-csv@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-2.8.2.tgz#21e90c28692d321615bd70b3936efee6796f55d9"
+  integrity sha512-haCiP2Tr8vJsR60ebigW5Pv35aJXtN1c4hckpjIHsyHX0b0Qa08wnb2KNgP0K+MPRbu83siaju7PcPVi1rDHNQ==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-sparql-json@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.5.1.tgz#2a7f7af51bc5ea4bf7a385d53a4194067569ee06"
-  integrity sha512-DGt6SInzYofftWhONKBcIFPOAm/3vIvePZ/jkiG1ncKimyvAClMJ7nQbXsFLfxhYdCKP7tALNZnOyKOYv4U2rQ==
+"@comunica/actor-query-result-serialize-sparql-json@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.8.2.tgz#ed371a70b8b29cbd3f76f6af0e1b42bb05661fd5"
+  integrity sha512-XtiSEuzCnmP2IkTlW2pQRQ/ErLZWgPcSw/J/cgS1Bg4RKl5q/njvZv2fhqsY3a79OAgRptMySVLmzcNIW59+qw==
   dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/bus-http-invalidate" "^2.5.1"
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-sparql-tsv@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-2.5.1.tgz#7ba826b10923848de0117c5231d1344dd28c704a"
-  integrity sha512-BNEfHE/JCTZ6NIns6I1MEPRDVPKE8WH0sCnMrAuzhLr4zNpKNg2GE/teCPYTyc4zEYHYpxmaftRJQDohLMRYaA==
+"@comunica/actor-query-result-serialize-sparql-tsv@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-2.8.2.tgz#d34fbd0c8ebba0641e831afb782e98c56a9f66c1"
+  integrity sha512-off09bx4VvyKMtkAXmaB+Y0iFqsnBPL8/QDN1kdDeqnJNY9n0fV5XPwB9C1XBZjqAmzcdzS3+Ac9hyOkhr1wrw==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-string-ttl "^1.3.2"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-sparql-xml@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-2.5.1.tgz#5e5d5b6707e8c9ee2c935c4a1b273ca16afdf9e8"
-  integrity sha512-o/kznhd9WoDtQ7D/Hz1doS7NMUpYeM88jMJFbtiePHVIUI2GVUFu32GZ1GXLw0KREeYZDAHpxTVX663AiWS0cw==
+"@comunica/actor-query-result-serialize-sparql-xml@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-2.8.2.tgz#f6207e8b3df58ddc58cf1f7ad67082e6b1ba74b2"
+  integrity sha512-fNpMstEwEnl7JsLmh9mA5mznuPnfrv3r2vezzmUmTXRFN4IrxjeSQvXY2oSUygQuWqLBoybsGxPxX9VhncHbgA==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-stats@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.5.1.tgz#fb9a2c74ce7cde4f85af730904b32239096dc839"
-  integrity sha512-/82UAxeWuKsLiT3OBLN589U3nERKKBbA4ho6LlYSakTFUbtEVuJfsBHKlr4/NL/WsJgypYa1DBUdf0oBUt0Dkg==
+"@comunica/actor-query-result-serialize-stats@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.8.2.tgz#09e9d948601702ef9c0f73edb9667374def7d372"
+  integrity sha512-DLO5mZ+Y8AVrKpK4W0gERUUM5b++i9GwPUqvLIps9wG+RPNWV4TbthY9PQmdG7WLefJBfHOiUSia6v86BTsk0g==
   dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/bus-http-invalidate" "^2.5.1"
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    process "^0.11.10"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-table@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-2.5.1.tgz#1e101b41bd92a2cdaedbc7a5e59e562c8b59680e"
-  integrity sha512-SrtjB2ThIoGz/fdqim5swfdfFmS3RZiQNBE939idK19vo0bJFvxqZItwH8TALvamvj9xW/VL72t7FwwjChXyhA==
+"@comunica/actor-query-result-serialize-table@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-2.8.2.tgz#7adbff0cd8d08952f5c3ba1cdcb91d474476d071"
+  integrity sha512-IK/LUY055QDqCFBXGLIl8nyd3cVcy3Y9adBYCxRDvAIdHqKZi/wBdZA35RuXfaWAbFRARABtJVJM7b7ekUzKJg==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
+    rdf-string "^1.6.3"
+    rdf-terms "^1.11.0"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-tree@^2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.5.2.tgz#15a8223d3b8a776a5a5fd69682242c953d8a876f"
-  integrity sha512-ZmIRwklu7gO7y6lRl+E4t5ygqk3diHf+ttKem+380CwZymxfbPiMGgI7kwGvEU/+MsjzQvJjboViL2R5bFWHOw==
+"@comunica/actor-query-result-serialize-tree@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.8.2.tgz#029322cd3981ae5f14f153117655a40c1a0d191f"
+  integrity sha512-oDG+84J6yAV7rnZWzWy9r7RDCjrWnVoBwYuieJBi3TrhQ1p5Ed69Jp5dpvqgeBVC6xANnEoUvPzk0QYLfEvyUA==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     readable-stream "^4.2.0"
     sparqljson-to-tree "^3.0.1"
 
-"@comunica/actor-rdf-join-entries-sort-cardinality@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.5.1.tgz#e05e56ae233a019379af2283efaaf52cf196d309"
-  integrity sha512-coGMfkEuW+zKYNQHmNb1Efwk0jDr/P2XZQWtE/FFkVvRA1FOmwrBUPC0mNCbxhNoRpGW62RKZOuu9Ptj71vqaQ==
+"@comunica/actor-rdf-join-entries-sort-cardinality@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.8.2.tgz#4f4dbb84f4dee0b8f7bdf8050fecef0b04c28af6"
+  integrity sha512-zQiGXcmu9obRxa0H1zEdEQ3oIjnnw9v0GZtafNSoYc/0GJxMJvo9phmAdAsftB6Yf9SvpqKIcbPhMIS1QiXD5A==
   dependencies:
-    "@comunica/bus-rdf-join-entries-sort" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-join-entries-sort" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-join-inner-hash@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-2.5.1.tgz#657cceeaec1aba52cce3bec0ea9b6c0c24b87a87"
-  integrity sha512-hlxRFeyEty2FS/+Di/Y8fcfcD55YnGgVZZhass+20v6RkrRW5W5pX65XS2y43/qVGr6kQY3N/Z1WnkUOuMZdxg==
+"@comunica/actor-rdf-join-inner-hash@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-2.8.2.tgz#b1168dd9b11eba446008baeecc4ef348f09266a9"
+  integrity sha512-RtGD8MwO+syomGv190qygAoU57e1+F343FJViwHF7WiI1T68cN5Gx2hBUj+cQZAILBsSgJPgT3XgDfsTjqT02g==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     asyncjoin "^1.1.1"
 
-"@comunica/actor-rdf-join-inner-multi-bind@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-2.5.1.tgz#903ebf1bba83d202b2403f413d11bb097956360b"
-  integrity sha512-Oob3+T+1yjnSR7LK9y2fMz9HIrtL90W5vEcz2DltaJEf5wdwnOaxbi3fLwX24s9RTJ3/k39dGR/BEyFWPx/wiw==
+"@comunica/actor-rdf-join-inner-multi-bind@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-2.8.2.tgz#37091e2303125848b40cac7c05845d31188ced6e"
+  integrity sha512-VFSXZb4Zk6zkQVItcvpSLWEu28j7CqHB6fmTz9SNjYO7PaQjrCnDwMV/xdtx7ZdfIiJi3gCafI3tOAONW8ZzEw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/bus-rdf-join-entries-sort" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/bus-rdf-join-entries-sort" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-join-inner-multi-empty@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.5.1.tgz#a579945965fb57c9664b5b07ed7de1f7bd6d048d"
-  integrity sha512-4WQWQv9aidu/SzznCkGd+1LtmWZdRYE+5j7Dg6Dso0E9oau2OVDk/gOuN1q34HRasgrBkoukbJKv02CxDUOJOw==
+"@comunica/actor-rdf-join-inner-multi-empty@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.8.2.tgz#9b40651f9ef9b850f58f79f561b8acb9f1de58ab"
+  integrity sha512-g59jfrYutnHO3Q/X4Sj+8vHbqH04Jn5PiddH0OjFFEgdEHkXOTqZ5E4y8X9MxxqN1Ca3E54fMCweyFLfdmN+gA==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    asynciterator "^3.8.0"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
 
-"@comunica/actor-rdf-join-inner-multi-smallest@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-2.5.1.tgz#0eb173ed5c0a9831d9501c33070105911ad148ee"
-  integrity sha512-zxJQinosmOF9bbaxVUSC2/jrKEnAGdsNpQy3+PCXEU9squJ05h6mtk6JD9e/TBAoPKUUVE3K/kQ/FQCf0MLYuQ==
+"@comunica/actor-rdf-join-inner-multi-smallest@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-2.8.2.tgz#81f34fdb50a217bb065f1e700e08e89e0f9caf56"
+  integrity sha512-heMn9G6mhufKGx8PCA74Hul3FoQjqDxtERp88rFqKwK2qU+UNNKD+FWcT/yHs5hajgD2upWNn9q4wxoqX+1XPw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/bus-rdf-join-entries-sort" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/bus-rdf-join-entries-sort" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-join-inner-nestedloop@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.5.1.tgz#7ede5fac9191b4684e45383f323908e3ee8907b8"
-  integrity sha512-N66xrvW9Bg/9LBa6cz2gkSmIxxsKGHeAvPuBhE4KkFFNumSWvmGLKyQ6Oh6s/tCe7Vc/tcyLaML9/FhIg4IT8w==
+"@comunica/actor-rdf-join-inner-nestedloop@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.8.2.tgz#68daaa354549dbf33fabcddd62c4d6c1297d6fbf"
+  integrity sha512-BborQRbSwNco40mLdP2SY383KLWKdwloBTXb6hUvkmvASDRNLrX39ouBbHWnEm17EO73O4mN8Gkfkse+hr9kMg==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     asyncjoin "^1.1.1"
 
-"@comunica/actor-rdf-join-inner-none@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-2.5.1.tgz#586a2f09c0e4eb366bcf2331edcd1839bd57e224"
-  integrity sha512-0QmH7Z+wD/SvBvVU5RWG26UeR6cIjluUi8jEYRRCGooVoTjGPLHvi5zxyNkHFFDafEgiVHqQwU/0Q8OWEe4CUw==
+"@comunica/actor-rdf-join-inner-none@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-2.8.2.tgz#9aeb35cbfbd88c0f6bd535059ce2cf5c3659aedc"
+  integrity sha512-eHS+n2hhM+0tFjqXULfSbnVJgx0NIIwTH6sdoxqIp8ARgJT2Z3IAZuFrE69BrOrhgjnJntSTmE+Jphid907KGg==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    asynciterator "^3.8.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    asynciterator "^3.8.1"
 
-"@comunica/actor-rdf-join-inner-single@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.5.1.tgz#f2c250fb980f82ec1cc76eb730c5b8e4b1750e5d"
-  integrity sha512-Zr2vVFMpgheY+uIk7b4GZQ3ucS80jKAWNOhpeBWojghRcm/f1e4QQrccTuBLu0RBH2YCQ8WqhtjoVs6qcG2yvA==
+"@comunica/actor-rdf-join-inner-single@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.8.2.tgz#d2afd8df04332edb8af5a69526183fd0dd820c61"
+  integrity sha512-SOCeTjwAycy6d2PVPCPzF3HIu+T2EWhtOrWEDhe0aW1egBTr919aEZQtqKYmwIW4Ih+mseDMGAK+moXoLrNZuw==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
 
-"@comunica/actor-rdf-join-inner-symmetrichash@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-2.5.1.tgz#a09a51d4c3b75a23d8342345cb52d31127f63094"
-  integrity sha512-98WsPreeD9XxfVAZL3D8RZpzEW5eCEcf35dPtDQGnrwxzelCkd+uQTMYCiPvk0LgSLMA1zGQ+3FGfXgVQ7JS6g==
+"@comunica/actor-rdf-join-inner-symmetrichash@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-2.8.2.tgz#004064c8c7e0902c1ea927031bb586d4c09ad063"
+  integrity sha512-8/ri/Au4JjIOQYUq86x4JPxvd10IBc7m+LzfgY8Ka9n0L5+PrOvGw3lfDJgWqQBQ0xla5MDdLpwDmHjwtP4H7A==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     asyncjoin "^1.1.1"
 
-"@comunica/actor-rdf-join-minus-hash-undef@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash-undef/-/actor-rdf-join-minus-hash-undef-2.5.1.tgz#700e10ba31d37fb38669da0890068e546ea30800"
-  integrity sha512-QySgPKO9CXl8QthokPLDd6rT8nFu7MCui24+gYi07G3qia07cYT3/RQIP+K4XGLfApy2538OhU2LvZbyQsIK7Q==
+"@comunica/actor-rdf-join-minus-hash-undef@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash-undef/-/actor-rdf-join-minus-hash-undef-2.8.2.tgz#54ee0deef5c3ac0d9fd7c164fc6b1ae3ad3cbbfc"
+  integrity sha512-48ugMUlv2BmbyNtJzM9XuiUl2Gw8t54GAHebaGTLmbxK0BmwI7BxstD9VOVO9eNnd8VzYjgmRJeQJri46rbzuw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-string "^1.6.1"
 
-"@comunica/actor-rdf-join-minus-hash@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-2.5.1.tgz#aae92384feb42f02802eb078e62074be2d3c8989"
-  integrity sha512-mi3xOZByA4beXjLL89yKHV5WKeJHz76spI8v9rSN366Cf9yUdep+LSy14GuXvmNikU1w2ydSu+R0gjm20bLfDA==
+"@comunica/actor-rdf-join-minus-hash@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-2.8.2.tgz#2c475da4c02c82fe1faa34f37b2a139d86c9bfad"
+  integrity sha512-SRnEYiQED5em9lX6vNXYi3IGbHFT+Fo6N3Ia+kUPgv/ym32rq4iYx5XYp4jX4zgSJN2x53fU3Nh/PnqKhX79JA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/actor-rdf-join-optional-bind@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.5.1.tgz#97303cabed46c049086ce69c37bc87e3ab7d1abf"
-  integrity sha512-8WERI1H7aIXyeMlIw0kpj9AS2WMKSL8qwWFbifXHmz8mdyEhHLJeeSxLCUD3in7BSkUaIRG7uaDlRBrlXHS1sw==
+"@comunica/actor-rdf-join-optional-bind@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.8.2.tgz#430251931243d6e3fd2cb3bd5bee4948bb0aa668"
+  integrity sha512-woDxHGQsQlQdPYiZ9uVuNpuMb2hDCOtU3DR+5V286cUMJIQaoG/cvXJh2IhY2m8lcPCJcCKUY/hR8D5/pqBRtw==
   dependencies:
-    "@comunica/actor-rdf-join-inner-multi-bind" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-rdf-join-inner-multi-bind" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-join-optional-nestedloop@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.5.1.tgz#a8806e25cb43c41ed49c5bff39e615170336255a"
-  integrity sha512-zhZ88ToyEM9/o6jZ2RCuQV4qWr7apIZhYoQzMQwvj3Jh+fCgNSnSQpaU0ybCY4ScltXkapqG/kShWKlEp4EMpQ==
+"@comunica/actor-rdf-join-optional-nestedloop@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.8.2.tgz#026c20619ccb0ad5b32ee4c34a1c6a92de9690e0"
+  integrity sha512-Q3Fg4UX0ZaNcqQtF7rJshIPyKTwCmHlxAZdtVqIRo9Dj4FQ50PX5ezMD+FSEOyOzpS5PqApjlnfBQ9rRKIlFgA==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     asyncjoin "^1.1.1"
 
-"@comunica/actor-rdf-join-selectivity-variable-counting@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-2.5.1.tgz#b595ab2d84404440cc8f92da0554d4281404fdb0"
-  integrity sha512-xOVtf24O846UwmF4fNw26E2zkBjgpTo56l/xdJ9Ii+dwRnlHRodJPULQfRQiGcDGMTQKL2LCmRCojmbmQTdYdw==
+"@comunica/actor-rdf-join-selectivity-variable-counting@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-2.8.2.tgz#1f5db2f416484c3c974b2aed79625e45d516ea45"
+  integrity sha512-NGUcIMpqvSTARJfhLDmiRDd4WY3dEAv4jYga1zB/4tJ+DnQhgDIrbKGjneTbv65taDQ7MTzeNfbhCNv8Luc63Q==
   dependencies:
-    "@comunica/bus-rdf-join-selectivity" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/mediatortype-accuracy" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-rdf-join-selectivity" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-accuracy" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-metadata-all@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.5.1.tgz#2248779c9dc64a040b876e19d725089156626bbc"
-  integrity sha512-UcGN29Pi9POrI4mJrRwWsJVxyRSuCx3Z745ipCYFeDuS/+F8i0P61l8Gw7a/HpUhcXDVBf7smjAPilyY7hB5yw==
+"@comunica/actor-rdf-metadata-accumulate-cancontainundefs@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-cancontainundefs/-/actor-rdf-metadata-accumulate-cancontainundefs-2.8.2.tgz#e6d4c6589807264f9ef8a5844abd5a9ee40277c0"
+  integrity sha512-tQTP+496kavL1uEfSksXhOrmzcYVjlsXpCnsOwO5l7niW3UO1YAw+T8cG0qVFmgneNk/jRH+JZm1Q0QdoqSo/Q==
   dependencies:
-    "@comunica/bus-rdf-metadata" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/actor-rdf-metadata-accumulate-cardinality@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-2.8.2.tgz#db5e84bab2251a45159edf5f8c1ea07af2602db8"
+  integrity sha512-5wrc2F/iCvfQq8quHUnXQyEDlNRjIwNPVqYkiXW9Ux85UZy8ytpSvqd+qZ/7XLL/U7Xr5+reBygQmu9+J3iIug==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/actor-rdf-metadata-accumulate-pagesize@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-2.8.2.tgz#b489374193f5da29a9579749fbf4aaa39c6d8b0a"
+  integrity sha512-W6O2adLYU400x1limh7U7/Q8sLA6yZiAPGie8mu/W6Kg/1ht/kPUtcIeCU70mxOQqSYMEfmVOl3uL/pIusWkLw==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/actor-rdf-metadata-accumulate-requesttime@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-2.8.2.tgz#892e7831658f3a4959fb4de35ec9b387d73c7205"
+  integrity sha512-IUZqSEFZE1hHWAXkc1MFoosbbCmDMyGyICP7AKsRKDyEo5f09UEXbL9M6aIslx5oSBzEwGRYcPrdTOOZi/+eqw==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/actor-rdf-metadata-all@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.8.2.tgz#af8e307ab938cbf895d871a27e85edd195e8d25f"
+  integrity sha512-gpQtNeB7Y65CRMMWPU7ybKfm1ETh1O9Q576pKaRwhfN1OdeTcK99bMRPCwu2FMZq5fpXgpFEz6+pNPod+NMovw==
+  dependencies:
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-metadata-extract-allow-http-methods@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.5.1.tgz#a098144c76a82d3bd0a856b49cecf5e461c464ab"
-  integrity sha512-PqOiiGIbwrvwdTDh1w0OobbyVdfqvRNomarnytj9eKQ+OvXhzKf5byyOoRYXCfqeE7ib4ynidnBTxhE2fMUdkA==
+"@comunica/actor-rdf-metadata-extract-allow-http-methods@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.8.2.tgz#3f3830ce7244d231a697e4f6306d73240d1642fc"
+  integrity sha512-blySkab/iCI6OZ5dXSycUBO2Og8i9FSPOfz0d67ELeFk01MULocUHNRPU9IvBVLMOJgt9SbY6xISsnNDYqNgjg==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-hydra-controls@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-2.5.1.tgz#ca6beb306adc34b3ef09da667e7002c886bf6aba"
-  integrity sha512-Oi7Nk8ij8RWAVnzbpX2fWiepM5ezeOiILAp5RpwmJ/NtXuDQFFCUdRzWjio4rX3OTcGhX5UeSoD1QDitQxQ8pw==
+"@comunica/actor-rdf-metadata-extract-hydra-controls@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-2.8.2.tgz#b768eff4c728f9207065464212761c8daadefcc8"
+  integrity sha512-cID6mNBpyvrA+kSMxxHjX/bi4IYtqWjaaitzSHaRihQeBmwpX0UhjapRm8qcLdIOhTHzOUgSqayml6lOpFAuBQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
     "@types/uritemplate" "^0.3.4"
     uritemplate "0.3.4"
 
-"@comunica/actor-rdf-metadata-extract-hydra-count@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.5.1.tgz#d75ba5bca338fcde0915898729ed81e49f0a6bcb"
-  integrity sha512-FpJRYfScfo7yxl9osSi5mZiehCsgOVFQ1/s9tV0NSyqUCqx6a1rXnRNCdPh1lUy0al2Z3S+QlmPohto8zUSeVA==
+"@comunica/actor-rdf-metadata-extract-hydra-count@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.8.2.tgz#5ad15b78ff2ef45e55c541f6836a546b6e338929"
+  integrity sha512-c/+zAzmEaraMX2HsK0E1pEFciioT18UKAGk6ZNT+lJ1q86LMx+Ky5RFH8FtvCB8dYdc7K6AuLWsRiIvVzw/K4g==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-hydra-pagesize@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-2.5.1.tgz#f8d5faaa7e1ad561df6f60948de4c5cc87b9d355"
-  integrity sha512-lGbeICQlbkvCc/f9KGYMpHIcfq4XwuVW+fZJSjtC7jx21KSynwdgP/U6n7iKpH1VFUgnt61QauE8NTHNR3ZVgA==
+"@comunica/actor-rdf-metadata-extract-hydra-pagesize@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-2.8.2.tgz#d81b37085d507da6a66d272a557d818fa5a823e0"
+  integrity sha512-hYkc5UTcnBFkbGgfx261amIqnlLTg8rhky74UjY5h6eSlXRCA/viAQuZhuK4jmguQsL4qfv0tAG+ASKC0ZEyGQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-patch-sparql-update@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.5.1.tgz#1f8c62982d2fb4728e091b8ae23c9f3cfac898c6"
-  integrity sha512-9pPzqPebAEYjmNBYstSyIKnFhvCJ3Ampqko5EY+T767aD3De19th0TE4a5n8E9NI5RmXXe2OYZfsS2Do7D04Rw==
+"@comunica/actor-rdf-metadata-extract-patch-sparql-update@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.8.2.tgz#e9abadaf5a733580dcf199f3e37797211d8e165b"
+  integrity sha512-UHVqYWGBOkVaE0gMvoj2kHIj4k2tSOPM4SnVX0y0x1vw5dpJk+NEwohbEPhYK70WUAzqDxPFHE2pPa8eeClE9g==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-put-accepted@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-2.5.1.tgz#d9e25da8a93bd8bcf33984d18b1d79538868c458"
-  integrity sha512-RVY55uklPH5cDh/w9SbUKBpK8dfExnvHXi9Ofn7XeSTCKlHi+1nmYkhrxr3AomWBfc5HfxPy4ww2AwmWtsWIOw==
+"@comunica/actor-rdf-metadata-extract-put-accepted@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-2.8.2.tgz#b6c34618562e33c40d5512b91293284a6feec6a5"
+  integrity sha512-nOkk6WC4aRNq7JpfiwYTOfZeLCKfe5sJgfG2yLFpeea8lUkwQBUTn6UM6ZkMy78euIkIpMuu19DuxmMdFwAWDA==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-request-time@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.5.1.tgz#f220cd5aa2c7e10e9b14d42859b78b478ccd4927"
-  integrity sha512-zC9ie8/TVyLSig4dev+saAAfV/VwAUN54j2Xonn3FbH8YXrxtYTyfqRml7aBWa/I3wZm1M2KVzHSIlChu+nH1g==
+"@comunica/actor-rdf-metadata-extract-request-time@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.8.2.tgz#4218c54ed22170370f03cb23a27090704902ade1"
+  integrity sha512-shluvPWbNXBovQd837+JT7EwAWwQTbnYW1h1DgbH7hI3RjNj+0rSRFUAGvXFe1wSC3xno/sHMAxjVFJ5CzKl8A==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-sparql-service@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-2.5.1.tgz#7ed7abc5287df0125afd7cddba385587f7ef7649"
-  integrity sha512-HdJnsjb7cF8f5YuodLgaCRKgIBFx5Oy6W5WYsByIBQyhl8i0PWjQ6xkjf6o6MUqqLIbEGZKymPHYAZvOgyIu3g==
+"@comunica/actor-rdf-metadata-extract-sparql-service@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-2.8.2.tgz#e025ea7e3aba3665311925704ddb45874a2b0ec3"
+  integrity sha512-uWOMyccUI2qX/fE70pgMrb2cJDIDc75LPe3UfCRodHaIeIW+2kYcQZDDR/f43EtrISbJrgLu4MMZVeislroyuA==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-rdf-metadata-primary-topic@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.5.1.tgz#421f12cba15eea6a7c835a8ae3ce08ad0e6e501f"
-  integrity sha512-Z+6EqBrLiDsS4i0crIDwUfMvdgP7mWm+SKv9MRWKcHtlmJnU8qNF3cLpA4kKL3huRSpMfPEuFdRGNlSRp6XLNA==
+"@comunica/actor-rdf-metadata-primary-topic@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.8.2.tgz#36c99dffeffb054e10159e1c8a97ec642d3fc59c"
+  integrity sha512-Wq4Z+03kQv9eaukTS9tW7FloZd7ggkbCgYUyKvevVKAmHQiZmX/YamxCsvuIPQBNUQedpUFCXhitD3uLZ4GwJg==
   dependencies:
-    "@comunica/bus-rdf-metadata" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-parse-html-microdata@^2.0.1", "@comunica/actor-rdf-parse-html-microdata@^2.5.1":
+"@comunica/actor-rdf-parse-html-microdata@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.5.1.tgz#8c1ac26084d67f6c63d8ba0b9042b5831e5bf9fd"
   integrity sha512-hXpIwvBOjBLLM4ppEcu1wofjNRFavP33OHpK/Z5toOE1oyrLLtwJFpFxgc1zobhJibYuTskLlhkaCo4w5wVASA==
@@ -1356,7 +1464,16 @@
     "@comunica/core" "^2.5.1"
     microdata-rdf-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-rdfa@^2.0.1", "@comunica/actor-rdf-parse-html-rdfa@^2.5.1":
+"@comunica/actor-rdf-parse-html-microdata@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.8.2.tgz#df447b1bcfc1641d1434424ec395267f6731241e"
+  integrity sha512-vJOjT0xNpUpwqf46oZoXj4hjEK5FrstyjHeuVe1nJruPCE2QMDIdt/wcc9SP2T/Px5uvEjDUgEoxAEOPWkADAQ==
+  dependencies:
+    "@comunica/bus-rdf-parse-html" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    microdata-rdf-streaming-parser "^2.0.1"
+
+"@comunica/actor-rdf-parse-html-rdfa@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.5.1.tgz#41baa95a097090f28e303f30bf235f285cd94d83"
   integrity sha512-hGQ2cZC3glZVdyk4CbmLS5aDTCVHirDYqZ35484MsEipitp+bOJ9/Zg/oXRjs7DtqKmtgqUgw8FGn7dUgnzHPg==
@@ -1365,7 +1482,16 @@
     "@comunica/core" "^2.5.1"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-script@^2.0.1", "@comunica/actor-rdf-parse-html-script@^2.5.1":
+"@comunica/actor-rdf-parse-html-rdfa@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.8.2.tgz#37bee07c35b957994eec35f7178c263d7c3247b4"
+  integrity sha512-Ipe5NWHZJsnGs8KZE1GbNIRIV5DyF+IOt4BR8z4QmQu1IjzkE2zFG/tT7hI4ZQ7jYjMwkW3xcfsK4FJp+MnhQQ==
+  dependencies:
+    "@comunica/bus-rdf-parse-html" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    rdfa-streaming-parser "^2.0.1"
+
+"@comunica/actor-rdf-parse-html-script@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.5.1.tgz#be5d51819e367c8b0483c65fdef147558cfb9350"
   integrity sha512-GArg4XS6CHJbnkABYzVmyiWqNhmRHJdCUWWFMJeqYOPK5Smt5FRDdpDl0Pkh4mcUt0RBRTd0l9zW6AcuLK7iug==
@@ -1379,7 +1505,21 @@
     readable-stream "^4.2.0"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-rdf-parse-html@^2.0.1", "@comunica/actor-rdf-parse-html@^2.5.1":
+"@comunica/actor-rdf-parse-html-script@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.8.2.tgz#23c726a874c11eab204da16a092b9f63f4c19512"
+  integrity sha512-4Y87tzHJREywzjCbS/A7lwPtrFXIdb6pEnyWK/UROsj8nw8M7UacKog6hyB0iyeZGPM43S9x0RC/u5RWA9PHrw==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/bus-rdf-parse-html" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    readable-stream "^4.2.0"
+    relative-to-absolute-iri "^1.0.7"
+
+"@comunica/actor-rdf-parse-html@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.5.1.tgz#8d7f057b19bf756695d16ab351fcda9b9712b61e"
   integrity sha512-2cbJ4YfII1Rvh7787/fA3OLn5+8mwp3qwiXQtxZEkuqRhsG635oUb4mQrKwywi3y2UzbK4i2fO2248qLK7HSgg==
@@ -1392,7 +1532,20 @@
     htmlparser2 "^8.0.1"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-parse-jsonld@^2.0.1", "@comunica/actor-rdf-parse-jsonld@^2.5.1":
+"@comunica/actor-rdf-parse-html@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.8.2.tgz#77a22e973465367386a615a2077e3211bfaf631d"
+  integrity sha512-SV7iBGETX8igGyB84TVxM/2ylvugDAfDNgxkZPxuEjJfi65YHSt/pqnXPYYcuZ5QCO59gjBVMoeSIdNvmCHoOA==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/bus-rdf-parse-html" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    htmlparser2 "^9.0.0"
+    readable-stream "^4.2.0"
+
+"@comunica/actor-rdf-parse-jsonld@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.5.1.tgz#092b7a3fcc308d71bc21d67fb19da3ae49d1f7b2"
   integrity sha512-zJxVAxDQY6CCJCrWHO+07f0PK2DwlSU00hJO2n5Y+7lkicmcUcgSbVxE3CEI0/8aq/8p2jUcCEs++hgIpeArlg==
@@ -1406,7 +1559,21 @@
     jsonld-streaming-parser "^3.0.1"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-n3@^2.0.1", "@comunica/actor-rdf-parse-n3@^2.5.1":
+"@comunica/actor-rdf-parse-jsonld@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.8.2.tgz#94d3e89fa3f733eb3f067bac1abb0a00d7fb34c5"
+  integrity sha512-6H5HmiMujyISzxMAGWDjpMjWb1VD/GYw7Jzx6GWy6M9tjxcvkJRlgUl0dXOhIOlh/0LohrV18bKnA8uUcILzZw==
+  dependencies:
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    jsonld-context-parser "^2.2.2"
+    jsonld-streaming-parser "^3.0.1"
+    stream-to-string "^1.2.0"
+
+"@comunica/actor-rdf-parse-n3@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.5.1.tgz#43aa8acbb8b8e001ab503984d317f437432b673f"
   integrity sha512-N6P7r2co80RFrjurldR+DCz7ajqj7Ck2QLuZhCaZZY2n6IBsfdt9QcYcuMlhykYjt+/u6tVQEuWj/XWQy6mpYQ==
@@ -1415,7 +1582,16 @@
     "@comunica/types" "^2.5.1"
     n3 "^1.16.3"
 
-"@comunica/actor-rdf-parse-rdfxml@^2.0.1", "@comunica/actor-rdf-parse-rdfxml@^2.5.1":
+"@comunica/actor-rdf-parse-n3@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.8.2.tgz#bc607db929bfbae18e1edd14db0377bb5916f39b"
+  integrity sha512-vNbIA8MsZ4AGUTdxm1wcccjPyH4moMV2gGH3ZLhf2c7/zvVHbRiVcD7FB3ELU0yHUD9o5H9UBSwsmLMWQTSxcA==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    n3 "^1.17.0"
+
+"@comunica/actor-rdf-parse-rdfxml@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.5.1.tgz#23aab18d006996139a9e07eb2d3f11d1e4715b32"
   integrity sha512-MKRSh3GIHXCOMHskcZPdggY7O5GkBfLNoNt4HYe+08jR9/Kib8rEfd4ErKi9mbuWJbXciA84HLt3ebZpmydaKA==
@@ -1424,7 +1600,29 @@
     "@comunica/types" "^2.5.1"
     rdfxml-streaming-parser "^2.2.1"
 
-"@comunica/actor-rdf-parse-xml-rdfa@^2.0.1", "@comunica/actor-rdf-parse-xml-rdfa@^2.5.1":
+"@comunica/actor-rdf-parse-rdfxml@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.8.2.tgz#3576c968f5ce3f3ea0fe1bd951f7bb3d4544ed0d"
+  integrity sha512-5SoYBhrPicqHQKUTK20mYZqILctrIcxjk9R+tdhlAHzWOIT3Usmx87t2/5V8Tf/mr6ld9snQIaYS19QtU8MQYg==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    rdfxml-streaming-parser "^2.2.3"
+
+"@comunica/actor-rdf-parse-shaclc@^2.6.0", "@comunica/actor-rdf-parse-shaclc@^2.6.2", "@comunica/actor-rdf-parse-shaclc@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.8.2.tgz#c477544aaae5209e0a2c6ad2ddc64f11698d0b34"
+  integrity sha512-O27yF5qi1wQ9KhHrdLpZ3+l6w8FuJiWnFvMWVlsGbs+9xCu5kC/LacAemhzfXFAXPHQ9siNjznNZ5g/ZV/cIgw==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.1"
+    readable-stream "^4.2.0"
+    shaclc-parse "^1.4.0"
+    stream-to-string "^1.2.0"
+
+"@comunica/actor-rdf-parse-xml-rdfa@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.5.1.tgz#4829f274f81560bd3b59869bbc94ec6e4f21681a"
   integrity sha512-NbNaGcUepRz908nAVytKmTFn0dXOLdG88oD8ldI6Aw0HDvQU6Iw5r5eSaunfZONYYFT30eTZrGUyg3efwwfuvw==
@@ -1433,130 +1631,154 @@
     "@comunica/types" "^2.5.1"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-resolve-hypermedia-links-next@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.5.1.tgz#056639966c1f2cfb3433164faef2098bd64950ca"
-  integrity sha512-Vg8SASexMo521l8mD2LWcenKn2r+nAGMC7FmNWA5PiofaJRuX6QM1pwNaGW+mBYNBgH9Vom21VLiYofZcBtODA==
+"@comunica/actor-rdf-parse-xml-rdfa@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.8.2.tgz#99902af8794f6e98d1d2bf02db5fabb07aedf8a2"
+  integrity sha512-8bGTXpDbUqNowoSmLXapC/4blKQHWicVoV5NfdTcCrB0Nxs+oHa3I5DJMShQ6EBwCWVaScYcCcGFWIvE2tQPyA==
   dependencies:
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-2.5.1.tgz#80e3499d61466ef20b06b34c3c7b946065a1f8ef"
-  integrity sha512-CEBHoh0SuNbodWdTFzqYFML4VzJWDYrlroezrdJgsQ5DFijw0LpK2gdpM/6jRR/RfTCxWvj1ctBNcAcK9i++1A==
+"@comunica/actor-rdf-resolve-hypermedia-links-next@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.8.2.tgz#3959fcf9e5b544ca3c372d1b080adcccd0e9480a"
+  integrity sha512-bHNpHoBoJgzaHgpTLZ22VrVs4fWLbA9PcNOQau1Po2yHB9FUq27n7Hg3Tw049CipnFu8cFcBIU74kNFJcwoWzA==
   dependencies:
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.5.1"
-    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-resolve-hypermedia-none@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.5.1.tgz#e001769a12165d4f4624307a78797bea39f133e6"
-  integrity sha512-5WI2yFOyGBq2DGHGEQ0t/iUx0RWhBoKpr9Wz85McgQ0QfYzO0UQiNETpmHSI9mVDrUdx7ylj+S8UtToSVdLXZA==
+"@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-2.8.2.tgz#9bd5dd8034f47637947ca214c411caa9f6b8322a"
+  integrity sha512-S8DfXtVC9T/T8vlIjpAPjTfz05k3pojfZtb/5H6xYDUml3dv1xJbaj7BFCzAm83+pnZlbQMrcacVQJZgG0zE7g==
   dependencies:
-    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source" "^2.5.1"
-    "@comunica/bus-rdf-resolve-hypermedia" "^2.5.1"
-    rdf-store-stream "^1.3.1"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-resolve-hypermedia-qpf@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-2.5.1.tgz#2a88c5306228bfa832214cca586f804b96245268"
-  integrity sha512-AlQn9ZHdSQ+Raf6TT2X8luxvBectIXhJ8yLaFoLO98FVjyEiAazQo0Z4reINpNl8z5567iUFECz/uWv3q0RveQ==
+"@comunica/actor-rdf-resolve-hypermedia-none@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.8.2.tgz#a002b5b3518243596f65a10a9842e075b6f5787c"
+  integrity sha512-jJ37VyGSQqUKFvrzEJpWmNMeEfoBo9XXzFpSaUsca7EG1JTdqOByIf/mNO+LW9R/zs2s/28Q4C1P/kNbZc7UQQ==
   dependencies:
-    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^2.5.1"
-    "@comunica/bus-dereference-rdf" "^2.5.1"
-    "@comunica/bus-rdf-metadata" "^2.5.1"
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/bus-rdf-resolve-hypermedia" "^2.5.1"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia" "^2.8.2"
+    rdf-store-stream "^2.0.0"
+
+"@comunica/actor-rdf-resolve-hypermedia-qpf@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-2.8.2.tgz#fa8521a923e041814973f5272444e047652d9733"
+  integrity sha512-RTZpu24oKIIlgZ8V/h76/1CaKZMojnkKCrPbrZz/H22TkCvAEhHL4QHblOExePOPM/Rd9jgpkDFV2FBPp3cVrA==
+  dependencies:
+    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^2.8.2"
+    "@comunica/bus-dereference-rdf" "^2.8.2"
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
-    rdf-terms "^1.9.1"
+    rdf-terms "^1.11.0"
 
-"@comunica/actor-rdf-resolve-hypermedia-sparql@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-2.5.1.tgz#3a60899ba5f57e51728e4d5938c8a28ac3e04b28"
-  integrity sha512-CsC7zux9DZwhKZtm60bLhj6c8x1E4kf8xY6+AD8U6oFDME8OAoRnFsvgn55NJaZH/uCRypLh7CdrBQN8TYmeSA==
+"@comunica/actor-rdf-resolve-hypermedia-sparql@^2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-2.8.3.tgz#0c7ae17adb46515a0f25fe2e840c0290009dfdf3"
+  integrity sha512-BWoD/wSnmDQou9KyrjbVH4C8t6VYRLL1Q4w+7KRWieu+qEtQTzeS5rPg1z5vS2EZf7Al1D3lc1/hsHn3LShCvA==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/bus-rdf-resolve-hypermedia" "^2.5.1"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    fetch-sparql-endpoint "^3.1.1"
+    asynciterator "^3.8.1"
+    fetch-sparql-endpoint "^4.0.0"
+    lru-cache "^10.0.0"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-resolve-quad-pattern-federated@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.5.1.tgz#8f0de74ace937a02b19a625e3260b4b3d98d4ca3"
-  integrity sha512-hN3/tTWJzA12n/eCXVWHgJg2bxNBcshC6c4K20TkA6W7nAT6Q4/M8P9s44wLtl+vuL1BbzG8MgEqZHZTUGylGQ==
+"@comunica/actor-rdf-resolve-quad-pattern-federated@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.8.2.tgz#f1960a6f96ee86bfae53cd95c40ad70b37fed314"
+  integrity sha512-hbHrKc5c61t3xi2BY8u/32IVMwSfNGYz8yuz0cPdb1UgIK4aoBuPBDO2GZ/L4FKuVgL+FGP3sx94knYK1YelVw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/data-factory" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/data-factory" "^2.7.0"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-resolve-quad-pattern-hypermedia@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-2.5.1.tgz#6abe04a62c5bf81d02de57a1e904124c749876c6"
-  integrity sha512-R/n7bYVkeESQ7PIGzpgQJbh1FfCocswAALmmRlnieYBK7QfE+oXodHk4coNgi30FH7ToV1jTrtbKuVERVCHTZA==
+"@comunica/actor-rdf-resolve-quad-pattern-hypermedia@^2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-2.8.3.tgz#131b5caebc8b8d6ec4d515af9720fa74ab7d8d76"
+  integrity sha512-Htt0Z3hdMv74HWCxUlIivEHpbNfsU1Id3uCAFzPUQHykhbDc0/7juki/rejUN1y8EdErN8/Qk3BEGEgsrNRObQ==
   dependencies:
-    "@comunica/bus-dereference-rdf" "^2.5.1"
-    "@comunica/bus-http-invalidate" "^2.5.1"
-    "@comunica/bus-rdf-metadata" "^2.5.1"
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/bus-rdf-resolve-hypermedia" "^2.5.1"
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.5.1"
-    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^2.5.1"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-dereference-rdf" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    "@types/lru-cache" "^5.1.1"
-    asynciterator "^3.8.0"
-    lru-cache "^6.0.0"
+    "@types/lru-cache" "^7.0.0"
+    asynciterator "^3.8.1"
+    lru-cache "^10.0.0"
+    rdf-data-factory "^1.1.2"
+    rdf-streaming-store "^1.1.0"
     readable-stream "^4.2.0"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.5.1.tgz#f4edba8d0317b08f005fa2f54aefab56f8f9acd9"
-  integrity sha512-JhJ1I4oSAPaEpVwK0uGI99X4lnpBtJDzVL5xqdYYB8iHNCSnmBdpCFUGaLmCsroUKOtAOb3HHKR/4X3bdUR8dA==
+"@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.8.2.tgz#49f09a07c2bd234ed9a2c791dc2977906e0ff626"
+  integrity sha512-J8QAN/fJDn7TWPICDkg30bkqUHtQdrNzvTZt1B8UHKjxMfhdsFgT49yoLtiT8opjs/y1nV069Yhb55xXxRh+bA==
   dependencies:
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
+    rdf-data-factory "^1.1.2"
+    rdf-terms "^1.11.0"
 
-"@comunica/actor-rdf-resolve-quad-pattern-string-source@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-string-source/-/actor-rdf-resolve-quad-pattern-string-source-2.5.1.tgz#65cad3950fcf030462bac095cb4cdabe443d4e2a"
-  integrity sha512-PDg4COz2mn9L9Q9Uci+axi92sr6j9F9LI0eFeOzT+Yj2O+puzXlIy6cyjDdCxFrGtfV26UFqpSfdbiV5/OXH5w==
+"@comunica/actor-rdf-resolve-quad-pattern-string-source@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-string-source/-/actor-rdf-resolve-quad-pattern-string-source-2.8.2.tgz#bbf2803d810448fc01fe2d6b9a10e3993dd66709"
+  integrity sha512-n7w5u+xvUVLvx4BPagYfJAMRwgC5pAGB3OMmWZBOix0Wid2MnUduXudyvllIsulgzy4i1o957jLRaDFoyr0pbA==
   dependencies:
-    "@comunica/bus-rdf-parse" "^2.5.1"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    rdf-store-stream "^1.3.1"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    lru-cache "^10.0.0"
+    rdf-store-stream "^2.0.0"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-serialize-jsonld@^2.0.1", "@comunica/actor-rdf-serialize-jsonld@^2.5.1":
+"@comunica/actor-rdf-serialize-jsonld@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.5.1.tgz#b2b4924fc946cb4c6f11bf557462c1e9f452f585"
   integrity sha512-QYyruMJBKYeIeTENMsBfCq3/fRUTlmMtOchRn0Hf8vWp+ZO5sx7EksvwA3hEJ0yzbHaNSOoi53I5CcJYNMG2yA==
@@ -1574,7 +1796,16 @@
     "@comunica/types" "^2.6.0"
     jsonld-streaming-serializer "^2.0.1"
 
-"@comunica/actor-rdf-serialize-n3@^2.0.1", "@comunica/actor-rdf-serialize-n3@^2.5.1":
+"@comunica/actor-rdf-serialize-jsonld@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.8.2.tgz#111c8e90c37066561042684bb12f10cf948b8203"
+  integrity sha512-PChSSIqoRm7Kml565iiT735hcEdDDlNP9gjE00CSng8ByFf8chjl2E+6fQG0xiQS2Mfi2QgD6tLCEK9+O18PHw==
+  dependencies:
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    jsonld-streaming-serializer "^2.1.0"
+
+"@comunica/actor-rdf-serialize-n3@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.5.1.tgz#cde99b853d2ed51314b1d0b3fdfbb8a20e71c0f2"
   integrity sha512-llK3kiNtqrEBTL5z8GIDM/SjT9nv41Pugm+H/j+hTjNIVfSCHpaobUuQdft7TDVYeXu6/U18lXcz8n1bAspKfA==
@@ -1592,6 +1823,15 @@
     "@comunica/types" "^2.6.0"
     n3 "^1.16.3"
 
+"@comunica/actor-rdf-serialize-n3@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.8.2.tgz#91c3af69220ae3ab4e04fd9957a80b03425a9f7c"
+  integrity sha512-ZlHdt6DpE5oRU13tlAlO7R14mwP/zGlooSSniUmbuh0vO1t8CjPe7iD1V8kj1KDH7E+aadIp50uc+nirGJKeQA==
+  dependencies:
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    n3 "^1.17.0"
+
 "@comunica/actor-rdf-serialize-shaclc@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.6.0.tgz#944c01e9bd04c0e6e74e7702c370d905cd4aa2dc"
@@ -1603,83 +1843,94 @@
     readable-stream "^4.3.0"
     shaclc-write "^1.4.2"
 
-"@comunica/actor-rdf-update-hypermedia-patch-sparql-update@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-2.5.1.tgz#f9992ddd88e77e783a5a2fce9b82a5ba994ba6aa"
-  integrity sha512-DKwK9r2Y79A9QLL6vtOG22AjlOhnrTw70MIM4/bJ/M1esV10+fK21fLSRsF0m0OCvqBVcUa/Tb76DsVZgCV9ug==
+"@comunica/actor-rdf-serialize-shaclc@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.8.2.tgz#1e83a447e9aaae820e7ba0b5870591e41991d6f2"
+  integrity sha512-rySVO0zN9S3B3CjKpbCU/yyIxD+QroaJ509iBbHmriGeV8HfefE427ZpwKjObrd6m3VVLdtyZz2dVW+bUMChXg==
   dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/bus-rdf-update-hypermedia" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    arrayify-stream "^2.0.1"
+    readable-stream "^4.3.0"
+    shaclc-write "^1.4.2"
+
+"@comunica/actor-rdf-update-hypermedia-patch-sparql-update@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-2.8.2.tgz#f181e42c536bae13544510044e5e5a5ca87e8d73"
+  integrity sha512-jvim0Z4jnSyNxNSiyf8KcMDXo1LMnXb10nFSP+YgUJZ/FjnoFS/wFQsZ8btOjDcRov0wBeEYHZnOhZ96Fd0T6Q==
+  dependencies:
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-update-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    cross-fetch "^3.1.5"
+    asynciterator "^3.8.1"
+    cross-fetch "^4.0.0"
     rdf-string-ttl "^1.3.2"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-update-hypermedia-put-ldp@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.5.1.tgz#b3976ffd39dd75f58f5c75ec3b487db10be7ba32"
-  integrity sha512-DAzgpCOsuCFa5usycX9TT6VXSV+zcxX7KzkjWQ893SHTn7G40dPhm+aWWyYYKGeuWvLrD7woHS/m5qhaupi9Hg==
+"@comunica/actor-rdf-update-hypermedia-put-ldp@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.8.2.tgz#0f68b349fa687d086856621449d5cd68d9b4924e"
+  integrity sha512-fM90gjF8OnlTz+5STBy5ZOmQW7dXB0AZqoYziHSDr18fNLHERWO8zmOmr4b4b1nI5UfcFgRaDguWdp9H70WcPQ==
   dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/bus-rdf-serialize" "^2.5.1"
-    "@comunica/bus-rdf-update-hypermedia" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/bus-rdf-update-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    cross-fetch "^3.1.5"
+    asynciterator "^3.8.1"
+    cross-fetch "^4.0.0"
 
-"@comunica/actor-rdf-update-hypermedia-sparql@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.5.1.tgz#b35c42cfc3794efdd04d0bd435021895273e4cfc"
-  integrity sha512-K1Kmz9gG4F0LpMzUAimJBm+gYiZmPbCHnlM7LC2R42FDd9hO/ev2SdxEES7nL7NNFQkMH6ixHE6+Uicnd910QA==
+"@comunica/actor-rdf-update-hypermedia-sparql@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.8.2.tgz#4bf1ab7fbf6cb29eefa53567b72b6141be9a0f60"
+  integrity sha512-lT10NQaVJ7hKJqaExkwN+77pa7TbyIF9VF7DwTubTJaS45L7WA/bAPDIkn7Xha0V8sT2wIP7Bivhk7/E3W1rmg==
   dependencies:
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/bus-rdf-update-hypermedia" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-update-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    fetch-sparql-endpoint "^3.1.1"
+    asynciterator "^3.8.1"
+    fetch-sparql-endpoint "^4.0.0"
     rdf-string-ttl "^1.3.2"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-update-quads-hypermedia@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-2.5.1.tgz#f1714ea31142a137dbd958dd31e920b00e843410"
-  integrity sha512-HuFE9mW2mjFjAx83z4L+02YF/JCv94i5BEveOwt9cf0jqWfBAj6c3jNtR9zU1KDApmWGekFDx2icoqv8hp2PtA==
+"@comunica/actor-rdf-update-quads-hypermedia@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-2.8.2.tgz#1b6f1fa75481c17c3ed56cf1bec449d989c6f615"
+  integrity sha512-7umPxakkfSe1HlyfMmoPZtk9/7Sd8nxVMBT1p0Mk6MxgEJoDLGN5y9ft3qYi6BSVoaipKn9QWGy+KuMrERYDvA==
   dependencies:
-    "@comunica/bus-dereference-rdf" "^2.5.1"
-    "@comunica/bus-http-invalidate" "^2.5.1"
-    "@comunica/bus-rdf-metadata" "^2.5.1"
-    "@comunica/bus-rdf-metadata-extract" "^2.5.1"
-    "@comunica/bus-rdf-update-hypermedia" "^2.5.1"
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    "@types/lru-cache" "^5.1.1"
-    lru-cache "^6.0.0"
+    "@comunica/bus-dereference-rdf" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/bus-rdf-update-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@types/lru-cache" "^7.0.0"
+    lru-cache "^10.0.0"
 
-"@comunica/actor-rdf-update-quads-rdfjs-store@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.5.1.tgz#dc4da8a9bc72ce4019f27cc78a317f8b9eda9b9c"
-  integrity sha512-G92GhSsT3bV988UbcEK9gVedyRBjdbH33SybvhO2ZQ+qgNgCdhZzv7UlEmQ/5L1Vk3kR8IJoBTeR4GfmpT6DRg==
+"@comunica/actor-rdf-update-quads-rdfjs-store@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.8.2.tgz#e2bc1d9233db06f898471bf918c68fda76b30fa7"
+  integrity sha512-DqTTNsQ6JHuLwBx1BVfK8BIE/24D3CtxA4I+LBeykUTaowrSSOBArCBHPyozt+nEz4GrXOKXPN6xem7rDi2tVQ==
   dependencies:
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
 
-"@comunica/bindings-factory@^2.0.1", "@comunica/bindings-factory@^2.5.1":
+"@comunica/bindings-factory@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/bindings-factory/-/bindings-factory-2.5.1.tgz#18fc7269dc8d11f8de28b8c8c21c80ea80464250"
   integrity sha512-w8L9t17EaBibuyDXQAjSK04E4E3s/WWsSCNQz7QzG8dpLqscLfwiE0OBJpqpqGZ8pBkgQPt/JyC2WAqwPi5CHg==
@@ -1689,15 +1940,25 @@
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
 
-"@comunica/bus-context-preprocess@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-context-preprocess/-/bus-context-preprocess-2.5.1.tgz#a52666d908c17b20997374d68da59142a0b3ddfb"
-  integrity sha512-XUa/g2vfUcj1daIM3eP8maJjwbAmiIN540JaGpY/P+E5l1iX4M9yo/ZiG8m9sm9QVX6j8LHIYVwVvrf/54Z9cA==
+"@comunica/bindings-factory@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bindings-factory/-/bindings-factory-2.7.0.tgz#b35810178beed08803ba1891faf50bcd017f52c8"
+  integrity sha512-NeLbBmqiNhyUCZSfqZfwZD50dQ5+DABgPbzfuZnbHq9uSfhxAzuGCzgrK0hmuwRHWOPBtmeRnyZTJorePuxTzQ==
   dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@rdfjs/types" "*"
+    immutable "^4.1.0"
+    rdf-data-factory "^1.1.1"
+    rdf-string "^1.6.1"
 
-"@comunica/bus-dereference-rdf@^2.0.2", "@comunica/bus-dereference-rdf@^2.5.1":
+"@comunica/bus-context-preprocess@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-context-preprocess/-/bus-context-preprocess-2.8.2.tgz#d0b9d066602d9803034a9088467730f2d31a0ffc"
+  integrity sha512-cDfiCiqBZkx+ApuZCxMgBpTEYIkbo4j1So+5pF0O3wMx+gQ0Y9rnfd2Xhw4WDZFZTGW7As52WKtBB419E+EG4w==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/bus-dereference-rdf@^2.0.2":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.5.1.tgz#889da41ddf6b31cb8bd6c4440eab6601522f6ff7"
   integrity sha512-QdATU52U4wpC2OILe0p9twbHbl9LjhyeTYblcc4FaGEjgJ/8TqiWpwIzZEnCPRdE+yOy9QNXLjna5/B7hVNHsw==
@@ -1705,6 +1966,16 @@
     "@comunica/bus-dereference" "^2.5.1"
     "@comunica/bus-rdf-parse" "^2.5.1"
     "@comunica/core" "^2.5.1"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-dereference-rdf@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.8.2.tgz#3af17791b6c70447f6f45c26d9b5c35a4f83d152"
+  integrity sha512-Q/4oM6AsVi2kr9e040kZtOaeHeFao8zeV8VUgC8WceATkT6FVK/+STzOFabny1yQHSIKC54kj24pfvXJftEYhQ==
+  dependencies:
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
 "@comunica/bus-dereference@^2.0.2", "@comunica/bus-dereference@^2.5.1":
@@ -1719,20 +1990,32 @@
     "@comunica/types" "^2.5.1"
     readable-stream "^4.2.0"
 
-"@comunica/bus-hash-bindings@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-bindings/-/bus-hash-bindings-2.5.1.tgz#c3a8b7ed4627c5f8e84d098fd4190da0c0663a0c"
-  integrity sha512-g8dFSKayGbCIDoV4Bp5KveGfApG2QHMLLGhlZg6WfiazVd04nadDyUHR70Yr3nY+zCsWtfVww5dP/YNgUpEoiQ==
+"@comunica/bus-dereference@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference/-/bus-dereference-2.8.2.tgz#3adacaac3fed627c721a0e49daa469746dbb781c"
+  integrity sha512-bg4A6fdkNv1CZkBJ33JvG3Xb6zloq7ElwtVMEBytzeuQV4/UuOrF8MYe9s6my+qRb3v4gDw9UYgIfePIDZMEsA==
   dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/actor-abstract-mediatyped" "^2.8.2"
+    "@comunica/actor-abstract-parse" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    readable-stream "^4.2.0"
 
-"@comunica/bus-http-invalidate@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-http-invalidate/-/bus-http-invalidate-2.5.1.tgz#493a3cac38574cc8c3bcdef2867b47993d5959dd"
-  integrity sha512-lbWS7ZV86BMf3jT4PKEDOTKPCz3WcLEoTcJqeKlC4nEk5OAUvMb+NqQsJ4TUhwVArz6kRETyh3Z2R0eT0tOftA==
+"@comunica/bus-hash-bindings@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-bindings/-/bus-hash-bindings-2.8.2.tgz#bb5b98ff44f03f668e614a2313fdec856dc5c4e5"
+  integrity sha512-u9ug7e08mw24NZraeOuo3qO5IFjGv88c3XPanhrtvy44xoV+uoU94KgQCwcirnjJDGHO0+tBc5ubC2+GAA/zVQ==
   dependencies:
-    "@comunica/core" "^2.5.1"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/bus-http-invalidate@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-http-invalidate/-/bus-http-invalidate-2.8.2.tgz#a761d527bc1b2d2c018ed531052084b4d17aa31c"
+  integrity sha512-hG+s+fo9o2h69DVS7VuMpnNeHzW8MJexyyzmnK1MsfGeyGIq/NmAmQGJw7kN6wYiJUgP+DlGTKlle7iCiqwgBA==
+  dependencies:
+    "@comunica/core" "^2.8.2"
 
 "@comunica/bus-http@^2.0.1", "@comunica/bus-http@^2.5.1":
   version "2.5.1"
@@ -1745,7 +2028,18 @@
     readable-web-to-node-stream "^3.0.2"
     web-streams-ponyfill "^1.4.2"
 
-"@comunica/bus-init@^2.0.1", "@comunica/bus-init@^2.5.1":
+"@comunica/bus-http@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-http/-/bus-http-2.8.2.tgz#b51b237383db1bda2b0f0315d84ecb53cc0981d3"
+  integrity sha512-Seh7NXgTCuXbExJYgMKQDNSl8tdxaQWg5GtNiZAePE0aUwaosa2SsLifex1DJN7P1dW2OAaGzZhTB6+v9dKX4Q==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    is-stream "^2.0.1"
+    readable-stream-node-to-web "^1.0.1"
+    readable-web-to-node-stream "^3.0.2"
+    web-streams-ponyfill "^1.4.2"
+
+"@comunica/bus-init@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-2.5.1.tgz#511b21a95f0af07a6914d442045a00bb65281e23"
   integrity sha512-TDakSkGzM+3xkZ+xBCBmzWNagmDWUc+F6TPYOFO8goaT1+tVrPh9wPD5t2n1zkKMzG2dOVT4O8jxUfCyzmNwKA==
@@ -1753,94 +2047,112 @@
     "@comunica/core" "^2.5.1"
     readable-stream "^4.2.0"
 
-"@comunica/bus-optimize-query-operation@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-2.5.1.tgz#be65020013534d70062f35ac873ca118de6f2f55"
-  integrity sha512-gkIYz6ZMkDZfvCqmBEbV0taHGfYdOx0UT60K1/2WvSeW9bzRGQ6nY+2IxSs9oNI3vemGfPGwppom4HJVublIYA==
+"@comunica/bus-init@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-2.8.2.tgz#8fb8225531de05b55008b5ac470dfd204ce00b3e"
+  integrity sha512-KvRHO0j7Z4YS1Czxm985US7/fa7aL8jUlmS1AyJnw9jcl1+gYhtDRbopyJ4DGBgfV1fxve+UFXs7gpROrrh3Ow==
   dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/core" "^2.8.2"
+    readable-stream "^4.2.0"
 
-"@comunica/bus-query-operation@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-operation/-/bus-query-operation-2.5.1.tgz#a5e3c524508e5453acdc22dbb052aa8b19bb5783"
-  integrity sha512-yvuhkr6aU0FMrPEC8OHz02+YJxTSguBYRltCo51DB9HBWhQhcnd6vt5QRHzyvLXg3STPQWZ55ET7CrQldzEk9Q==
+"@comunica/bus-optimize-query-operation@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-2.8.2.tgz#d61476c2d6691205f842f91d3d9bb6b6bc82f94f"
+  integrity sha512-jF2qNmpduRwYbCOMHJBXphCY4VOUV3tpsLDboFAzUxCD+SAzNQJ3KdlW5vBwKN2bhu2Trn/b9baRcZxPBiorDg==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/data-factory" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/bus-query-operation@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-operation/-/bus-query-operation-2.8.2.tgz#698a129158b320f0fe6d908c525a65f32a9e156f"
+  integrity sha512-0UIctIa7/VJ47CbdVFj8tdVFQWuyAuWf+LlM5gFLBbvPhM2hP8mBr01dR8U8Cnp7oAs40j0DyJjeb3LjftgvrQ==
+  dependencies:
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/data-factory" "^2.7.0"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/bus-query-parse@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-parse/-/bus-query-parse-2.5.1.tgz#a539c546427e30841b2b0800893f6f55d558b7b1"
-  integrity sha512-iEXayASZuk0cGvlLt0U/VKn3XGOkRa4/jeJHeZfbFlYZeG2Hg8BqaxoWii8GbuJ5Akq57wfsoZlUse70JnRMow==
+"@comunica/bus-query-parse@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-parse/-/bus-query-parse-2.8.2.tgz#482a4e5a510d42f208680340ebe26ac8d272f1b1"
+  integrity sha512-FN8ZC3rPS1p9J7zk1VllXd5cg5DSwLjFQ2wuKgsTlJLiw5nlcpc8ufwRolVsywCRVxqaHPFIKZGTXUKFh2kPeQ==
   dependencies:
-    "@comunica/core" "^2.5.1"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/bus-query-result-serialize@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.5.1.tgz#8bec6d614ec59c547729a527f5c105a754bd8bfc"
-  integrity sha512-rnwIETo3kDAML8zfgVg0O+9bPt2gpAhkJS/c9Vx8kjqTt76AxDMGpVAZgikR3ONoQgAUDFbPMtO/V86yOnGY7Q==
+"@comunica/bus-query-result-serialize@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.8.2.tgz#491fec95827f5ecb6ce309bb3791a4dfaaceaea2"
+  integrity sha512-DN1J0ZT6lHh3s24wvZzLZ4wsaJxQ/P16Oax+mTXaMf/zlXhu2ZgtXkiPt/BGtz+bVDESJjaCnq/aVSrEh28dkQ==
   dependencies:
-    "@comunica/actor-abstract-mediatyped" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/actor-abstract-mediatyped" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/bus-rdf-join-entries-sort@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.5.1.tgz#1fdfa678bf27c856cfdbe244e83052350b9a1abf"
-  integrity sha512-VZMM9QgMWLQGPCqzQys72hYutuUklJYzMmQJZ5VwSVYu7//C+L4E6/nacOdqfiJ4hic3dwROFUO+G9YkQkSyXw==
+"@comunica/bus-rdf-join-entries-sort@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.8.2.tgz#12a4b84c3168bb9cb9bfe8f04898c59dac00d63b"
+  integrity sha512-qU06NvVdcBOl4zOHyCzA41REH/6mf708pdUNcyUZgJYfsBO3i9XQ28AHAmK+W/4AWY0sYojiIzTarWeFZ9D5yQ==
   dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/bus-rdf-join-selectivity@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-2.5.1.tgz#3f257aa4678a109c6b911216a4ca9bb988208e6a"
-  integrity sha512-3VL3oMyguQ7lwLBYy7l7a3Nuv2QlW0KTyPikJqdBduJFm17GsNT/yi3prct/BqmLfH7eQWGDk2C4yki8FgyKqQ==
+"@comunica/bus-rdf-join-selectivity@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-2.8.2.tgz#cf040111bde8f2da5908fdbb9e657f6bb878e5c2"
+  integrity sha512-0baorPXbBlOa/X5qL7RzjpGflWt4zTFNVBR79/KFIQZZ10kjCA+wGnooqnlUuEkXqxfKACs7dAcMsh0pM6TePw==
   dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/mediatortype-accuracy" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-accuracy" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/bus-rdf-join@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join/-/bus-rdf-join-2.5.1.tgz#3ca22d321484b5f1e4d2e3c62dad4015e9fe0028"
-  integrity sha512-CxxFbsCab/LLsc9NR7EVJCAZcuLOXsrb6x+GrAZLZLyWc8wo7HwxF2rUQqfswC34XXBLXx1HjDzoQDdiPL9ymw==
+"@comunica/bus-rdf-join@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join/-/bus-rdf-join-2.8.2.tgz#3d056d7bbd5da687777aaaaf0a04766e4568101f"
+  integrity sha512-6wMIR6Jk6poQ2RGKphBcrayCukWjzNL/AvFxtaQLjl8Qd/n4MFwGkRuLB9DF6a2QkagzNfu8xHlHpfgnotulvA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.5.1"
-    "@comunica/bus-rdf-join-selectivity" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/bus-rdf-join-selectivity" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
 
-"@comunica/bus-rdf-metadata-extract@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-2.5.1.tgz#157864f8a3304a82568574eeb6a81617404fac3f"
-  integrity sha512-shAiYs7tJyhjXDc4zLvgcJCrYedP9dUh0gPTtZKJTl5YMLiRP04FeKU/F/ZyP+wNgoxGC2XfH8Hg2iyll5sSug==
+"@comunica/bus-rdf-metadata-accumulate@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-2.8.2.tgz#8e04d2e7144b525c0cad57a07aaf832b8163f6e7"
+  integrity sha512-Tl/DfkqLsn800rqcfj+/ntY2CiDs0YYoCPfMV6WL4xpaVVWTjWTUXSjDEpEzXdMTlrje0A66N5nSt88qDAlc2Q==
   dependencies:
-    "@comunica/core" "^2.5.1"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/bus-rdf-metadata-extract@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-2.8.2.tgz#e26b1d7dda09e47d125230d57c91c2c21f57ae3a"
+  integrity sha512-9PofdgPuun5lcRjpO6DlpLlnsVlcy1qBAx2mqe3mzIYVEfOHXWrdE+Dn54AEIic5PkZGJT4k6xxelv8G3HDwXg==
+  dependencies:
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-metadata@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-2.5.1.tgz#b8c0cbdecea37e834b115ca3873f838d567d3ef9"
-  integrity sha512-MlxyTz1Vb+d3ixE2A1Gr9dMgM55Xu/sHfONCaKW/nxU3hetk7z4sk/hvkBw77T3B6Tj/j7Je0JJiK8lQY/WXLA==
+"@comunica/bus-rdf-metadata@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-2.8.2.tgz#983b8c61f1a1aa6942b2b245dd6d21b16a6f0229"
+  integrity sha512-g1JznI5motRlGwlZbX9IwflJfnt81QQqfdlDLmHZQxMdjvVeDPNcmdvimguBTW6MoU3VLJhiDchXp9rh9vweZA==
   dependencies:
-    "@comunica/core" "^2.5.1"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
 "@comunica/bus-rdf-parse-html@^2.0.1", "@comunica/bus-rdf-parse-html@^2.5.1":
@@ -1849,6 +2161,14 @@
   integrity sha512-+YZiAbA2h82/+FGDJPjqHdfq6l0dm3W11V0jHcOaAsk+AK2JvvoouYdFAGshhroxQwv5WPsXbtzy6XJmVtZ4MQ==
   dependencies:
     "@comunica/core" "^2.5.1"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-rdf-parse-html@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.8.2.tgz#a2e07b39ea64b0759b61a7f33a6787d8c8e5fb43"
+  integrity sha512-r20sl/NPC2YJCPFfWUCSYVZzYhoKK1ZJ0UJ8HubKte8EURG3TqUb9hQKSMcq9GbqSASR/lPUwSLL4VuKKD3aTw==
+  dependencies:
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
 "@comunica/bus-rdf-parse@^2.0.1", "@comunica/bus-rdf-parse@^2.5.1":
@@ -1861,43 +2181,53 @@
     "@comunica/core" "^2.5.1"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-resolve-hypermedia-links-queue@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-2.5.1.tgz#a7f675462878bac64f1188e7f2139caf5bab3fda"
-  integrity sha512-Pok20ehE7anS1CmRa01Q0mWIZBSZt3ibmuokmcDY8AO8p5sT6w6jy+/YZboIPFyGY5WVmlJoc1/fndXuhGnH+Q==
+"@comunica/bus-rdf-parse@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.8.2.tgz#cec32710484186e103fbba1e958fd59fc513538a"
+  integrity sha512-XimvJuWJGuolpUs4w+im4fw8Lc8jPj6gKM/2fE/cenWO/m6RafnvcOqjMs80toueuoFRaF/TIxOY09t6G+p0VA==
   dependencies:
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-
-"@comunica/bus-rdf-resolve-hypermedia-links@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-2.5.1.tgz#1fcc2950845d015708c61d3d52f834ea7fe6b855"
-  integrity sha512-tmd/v3njCF7LyzG/039zo9TSVLF8u24GifeAQb3mqJtF260uzNTV1Os//P7DKg5LdNG42o77LsA26SANRjYhxg==
-  dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/actor-abstract-mediatyped" "^2.8.2"
+    "@comunica/actor-abstract-parse" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-resolve-hypermedia@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-2.5.1.tgz#6c43f31c58cef6a6ee84c8e6cf534967dced62cd"
-  integrity sha512-gC4BV5yVJQCaDv6Q5EFXrf0pjhlDj1rGszOChKDK3RR8gRH0M0TrVFJVxq4RRTfj5at5ZFYuxRUEH8gJMPX31w==
+"@comunica/bus-rdf-resolve-hypermedia-links-queue@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-2.8.2.tgz#fee89493c8c6086560d39634b8e4a29edf542734"
+  integrity sha512-oUHYfWHNczCq6CHN2wKWV5+SeMlp9lEsJ+2GycrHPKFsLxwSAFelxi3FZgNowwFFR62Wp/UkPi4RjcA6UN46og==
   dependencies:
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/bus-rdf-resolve-hypermedia-links@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-2.8.2.tgz#1691b68b264aa2433ba9320561a0c416b29cd218"
+  integrity sha512-RFHEcPs/UGziKfxLKJhufVVusVH4rMvwEI7y1QQ2rlDFErL8fNjzz4vUioBnigS5KqNVJHphszZkgSpSWDrdWw==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-resolve-quad-pattern@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.5.1.tgz#99a3fe7c74faa4c4a99deb0dd31939aa53967c6d"
-  integrity sha512-i+egf/Odogi3i5afDx7P/xVbFpCPkJPKd2nC8f6pvgED3F8cGzfJTOBogA+T9GI+2vgKBAMf1Bi33L585gbDlg==
+"@comunica/bus-rdf-resolve-hypermedia@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-2.8.2.tgz#4736f2ed69f81b8cfb3c2aa082b372ca56aa1d8a"
+  integrity sha512-Jyepb3vCQ63T217e5AJcUZp+5EmJI8y2ZHAvzl050x8YKZRUTST2gfMoY3rB8WCPs7TFn9R2T5bR9ez/QRwOZg==
   dependencies:
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+
+"@comunica/bus-rdf-resolve-quad-pattern@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.8.2.tgz#ecebf39061020b2ad3b972ce1cd57686de7b4f39"
+  integrity sha512-TZPa/h5dERgL8oJY8wZn9fR4lxaE9cgiwPRJKgZjGN4mM8MaBY76qZXa55EqbcZnj4YihpLUoHcizj1cqC1mKA==
+  dependencies:
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
 "@comunica/bus-rdf-serialize@^2.0.1", "@comunica/bus-rdf-serialize@^2.5.1":
   version "2.5.1"
@@ -1917,34 +2247,48 @@
     "@comunica/core" "^2.6.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-update-hypermedia@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.5.1.tgz#60bc45429b637dbe95cebb2fbc6970c0b00d358e"
-  integrity sha512-7JGpiJBlCybpTN3MQy0NJ4Tn5J8/Strnqs7bCgILUMZyGbSpC77QxwyXXkyzL1SG2d+wvW0epyxerghA9GAh2Q==
+"@comunica/bus-rdf-serialize@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.8.2.tgz#77660f0c66a935f926fd0633389a726255eb940d"
+  integrity sha512-HAmDo3p1uw7WM/oUERa+1/UKcoATIHk6DCJgzXBWocwniCLb7b2sHQJR/SteFyH0U01JIgIn7cYyQsFkmfewHg==
   dependencies:
-    "@comunica/bus-rdf-update-quads" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-
-"@comunica/bus-rdf-update-quads@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-2.5.1.tgz#85dbf2dd54ee82a55069997eaa23395b1d13c211"
-  integrity sha512-0/7l2sQlPYgjbWzU5UTAlOv0oO1A7BaiS/SD/F/ySKeCV3cdiNupBcvgw18EdfGy6/AaVcKCRuInG1UKtixAyQ==
-  dependencies:
-    "@comunica/actor-rdf-resolve-quad-pattern-federated" "^2.5.1"
-    "@comunica/bus-http" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/actor-abstract-mediatyped" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+
+"@comunica/bus-rdf-update-hypermedia@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.8.2.tgz#f51e19bf7a620116834bfbf89c6db8bf0b7d2687"
+  integrity sha512-H0fGi5JICU+zY7FXnTAwWtmowDW9+TmDZhiOK97kmQEkrRI+/oSwuie0dQtft0IfNpcklEdNBVWLxS4hoFFsSw==
+  dependencies:
+    "@comunica/bus-rdf-update-quads" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/bus-rdf-update-quads@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-2.8.2.tgz#d1e2c6e4d4ad504e6918ab2c14f5fbc3768e9ca4"
+  integrity sha512-eo+PXI4AucGVpUttGVOVqhi3TTuGedV2Q0+26SKnFceMb728gmlf6osT7RXxrknv/fjCHMbhQ0XWCrqLBq2wQw==
+  dependencies:
+    "@comunica/actor-rdf-resolve-quad-pattern-federated" "^2.8.2"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.1"
     stream-to-string "^1.2.0"
 
-"@comunica/config-query-sparql@^2.0.1", "@comunica/config-query-sparql@^2.5.1":
+"@comunica/config-query-sparql@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-2.5.1.tgz#35a18f901fa34f60ca459486152a4bf07633bac6"
   integrity sha512-Fg/PDp0BwoFcCBeVTPTDR8pgXjuuMXTLi3SJFT0GdgtwSPHlAikMHGywyOMK9I1TlZ2Fwwl/oIhZVNFY3Uz7YA==
 
-"@comunica/context-entries@^2.2.0", "@comunica/context-entries@^2.5.1":
+"@comunica/config-query-sparql@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz#1030ee76d5532bc6a09a6c8af26a06c7311a5861"
+  integrity sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA==
+
+"@comunica/context-entries@^2.5.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/context-entries/-/context-entries-2.5.1.tgz#f3df1155303fd6f280123cea4695c68f5411dd38"
   integrity sha512-TnF476Nv9+DfZ+JLTQU7OSqmFREScVkpBtU71seT6He+vkJBHDm6Nq4tnKwDmAI3v9dCc5dgCRU4F2uPDjBKZA==
@@ -1954,6 +2298,17 @@
     "@rdfjs/types" "*"
     jsonld-context-parser "^2.2.2"
     sparqlalgebrajs "^4.0.5"
+
+"@comunica/context-entries@^2.6.8", "@comunica/context-entries@^2.8.1", "@comunica/context-entries@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/context-entries/-/context-entries-2.8.2.tgz#d1c8e46756c05e84232679f53d35a7f4006e9998"
+  integrity sha512-Ycub6tUiK3qYjKaT74DiThv4IKq3M4SAvDB0AdFvcevwcU6OK8Z6H7M7uA5LehJiEKoBwiO4Ff8iuv3xqAF+tw==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    jsonld-context-parser "^2.2.2"
+    sparqlalgebrajs "^4.2.0"
 
 "@comunica/core@^2.0.1", "@comunica/core@^2.5.1":
   version "2.5.1"
@@ -1971,36 +2326,45 @@
     "@comunica/types" "^2.6.0"
     immutable "^4.1.0"
 
-"@comunica/data-factory@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/data-factory/-/data-factory-2.5.1.tgz#c4b44d3124219a305aff85437c121bf456bb93a1"
-  integrity sha512-QngIzTIgEkgO1yIuoXADz5vQV6jXqmKMVrKR0E80Ko73pPnc0fah486CD2Q1CMI613rwStH/U1Sot2t1DOhi9w==
+"@comunica/core@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/core/-/core-2.8.2.tgz#ed1006d076ccd8f87180cc66e0b242a92c527815"
+  integrity sha512-8UrhEilUDxRTltFCI4uxz3nch02lGK1KFHBUCUxp/9EmnnQUYvwbMCMS6sLxYHTqJ18/SMFFEwgBMsTX/N+wuA==
+  dependencies:
+    "@comunica/types" "^2.8.2"
+    immutable "^4.1.0"
+
+"@comunica/data-factory@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@comunica/data-factory/-/data-factory-2.7.0.tgz#616f9abe7804f3627aadc0baec2632a9c68ec62b"
+  integrity sha512-dSTzrR1w9SzAWx70ZXKXHUC8f0leUolLZ9TOhGjFhhsBMJ9Pbo0g6vHV8txX5FViShngrg9QNKhsHeQnMk5z6Q==
   dependencies:
     "@rdfjs/types" "*"
 
-"@comunica/logger-pretty@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/logger-pretty/-/logger-pretty-2.5.1.tgz#5cbfb38ff5aa0a8f5be4b9be7fd8f112bcd4167d"
-  integrity sha512-iTSnHEl9CVuOfytK/3PSpBEHMEGL8nREQ74c0aAK//Dr1tFTLY2HPDvbQ5IRionCyDX1u/5vEu2JpP6n4pqFJg==
+"@comunica/logger-pretty@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/logger-pretty/-/logger-pretty-2.8.2.tgz#aef33c0e652280dbb9b3011f1bdbfe971ef02807"
+  integrity sha512-aeS2/+zAYMiTokAaGQ8kuP+tapGi2hjXwNUeRl0OzhPLYU7x1hZamqRScWBWLrIFNwRR3p4EVcH8mJC3y2P9PA==
   dependencies:
-    "@comunica/types" "^2.5.1"
+    "@comunica/types" "^2.8.2"
     object-inspect "^1.12.2"
+    process "^0.11.10"
 
-"@comunica/logger-void@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/logger-void/-/logger-void-2.5.1.tgz#6848797b3c2a6b776f01cfdf56be9e10f276f93c"
-  integrity sha512-q+7NT4etfh/LVUh+QGW8zY7RdxXytcFo5LQOQPovJdaXHWAZwFjeTQ6EMQFjww++zfgE1Vbbf+R+HPS1hvNKpg==
+"@comunica/logger-void@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/logger-void/-/logger-void-2.8.2.tgz#cda5aa7b25f0c343e831c0b9a4c264bff0ce534d"
+  integrity sha512-76VpfNCCO034PBSn4SUBp0CpbPhRM1g8AVJ5TV29RygOkOYBv+p3Pdzxgt/ITuyRswbuet0b553DpHkGStUTNw==
   dependencies:
-    "@comunica/types" "^2.5.1"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/mediator-all@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-all/-/mediator-all-2.5.1.tgz#81aa5fbf2b67cae05c9968cfb96396942a67d3ff"
-  integrity sha512-340Ah4fO1QJxoInw53R9ogrlVTAxgKstoEXjMr48cEIUcWkuUbYJ7tvvP5unhgpSYRRjeLWRBVbiEKT9b16+lA==
+"@comunica/mediator-all@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-all/-/mediator-all-2.8.2.tgz#46ec6361d1576f9314deb5f9da0576cfe23594fc"
+  integrity sha512-O1ZaeC70D106F38uGHZWejY1HajMhyY7PpipDrt+Kvdt8JYcfVkTx6dN1DFkyJ8PVmJnRrZkMqj1q1IunSJDag==
   dependencies:
-    "@comunica/core" "^2.5.1"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/mediator-combine-pipeline@^2.0.1", "@comunica/mediator-combine-pipeline@^2.5.1":
+"@comunica/mediator-combine-pipeline@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.5.1.tgz#54e9a40ed28afdd3a44d71f6324d35bb426ab3ff"
   integrity sha512-vsi6YA7NGPQoNSPtKHWUbsDK+678w0BdE9DEzLWOa2pqiWoeT4SuJV4szHQNVuJjzi6j6VTXuR58mZL7XqreTw==
@@ -2008,58 +2372,87 @@
     "@comunica/core" "^2.5.1"
     "@comunica/types" "^2.5.1"
 
-"@comunica/mediator-combine-union@^2.0.1", "@comunica/mediator-combine-union@^2.5.1":
+"@comunica/mediator-combine-pipeline@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.8.2.tgz#09333ee9e69202ec34a37613229f999281beb138"
+  integrity sha512-XjN3EWdKC2XDY6gr1po5GttsRuM1FewzW3KRlLoYkRzH0+S3Th5Ef6zTlgDef4tWqVgNXIzC5Ccz0HraKKEbdg==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/mediator-combine-union@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-2.5.1.tgz#18fb5fcd8ea091089306fd9cb4ebb4d9e2a04720"
   integrity sha512-vpbQn3xtoX+F00xv+AKbn+qUe66rIiycbiZoE/s/qtlmUbVKLItEMMuToDGRdcdC9mtPiieIrgremXd/RVdHTw==
   dependencies:
     "@comunica/core" "^2.5.1"
 
-"@comunica/mediator-join-coefficients-fixed@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-2.5.1.tgz#e89ea662ccbf35f3582eae525b39112dd2b39c70"
-  integrity sha512-vov/gY5u8l0XcVfEqC2bh3ZgRvLmeFQEA4XgoFfpHOAtzJQR6/I3PdyC4OdeJj7IzPIlXPCawvVf2P7m+CGBcA==
+"@comunica/mediator-combine-union@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-2.8.2.tgz#71be8ca6050443a49cdbaf273434895d2c780168"
+  integrity sha512-TjSHJdtbdiV96m+GaPUT+44Q4SOG8dcESO3YuJhRklAf6oOYfXL9d+7ITixSo7tiZQSv1LlgxG1apzBDTM1BvA==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.5.1"
-    "@comunica/context-entries" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/mediatortype-join-coefficients" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/mediator-number@^2.0.1", "@comunica/mediator-number@^2.5.1":
+"@comunica/mediator-join-coefficients-fixed@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-2.8.2.tgz#c230d19e4ad02a25bceeddaf08a7085fffc2726e"
+  integrity sha512-Dj8bLOMY8YI6u+R82u61IL3QeZaT828iTmls1SM2P/RDYzeSLc/7WMmxjSBudt37r+BNoVnVajN5hsoh5jTHFA==
+  dependencies:
+    "@comunica/bus-rdf-join" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/mediator-number@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-2.5.1.tgz#77579f4a2ade4f5c292448ab8434cb8993ffcc60"
   integrity sha512-pOTtj5WJEh8gNlNesxe7YG90J2dQobp8ulkzP/bzsd/DC14OOxYlcTke/c+GqZH6SaatUmz/R7Za5AWdipqYcw==
   dependencies:
     "@comunica/core" "^2.5.1"
 
-"@comunica/mediator-race@^2.0.1", "@comunica/mediator-race@^2.5.1":
+"@comunica/mediator-number@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-2.8.2.tgz#447f7951db02e24755b3dc477bf0326bbc5f12ad"
+  integrity sha512-7VP1bMUusiG7AecQxrPfSunK408+oW4kdNNjavEJ7+pLi/95bT/e/rq/0wbK9Wu0vVrn7JNbliekLdhdI/BIuA==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+
+"@comunica/mediator-race@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-2.5.1.tgz#6c8e3c906fc2c3215a4af5a719a5b6b5a78ca607"
   integrity sha512-VuHHZSDagK9k85NBTEvbbhkb/Xd9zgt9jBlYIVRarushJ8ihqfs8dXQ2Hs0gdOTyrCMFiQIimbN1h58QcmmKyg==
   dependencies:
     "@comunica/core" "^2.5.1"
 
-"@comunica/mediatortype-accuracy@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-2.5.1.tgz#fe37b4a48d37e8df70d2a3a4e2bbdc32411410cb"
-  integrity sha512-RafpK2bN2tCVZ069aYESX8X7qGEGVYQwrXUU8R91/dei2IjTNsFZvGgOk7VyBB411HRZ9hHGQpRnC0tHk2ZzgA==
+"@comunica/mediator-race@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-2.8.2.tgz#d77507aca27170599943c2bb1c39aeaa14134831"
+  integrity sha512-oD9bw8YLV8TTedFBigPuqWKNxu64uLwsfve0OYV2J0tZHPTiYp8XJoeWN1mxc0q4TimxqXfKn4gXD5MP06MUsQ==
   dependencies:
-    "@comunica/core" "^2.5.1"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/mediatortype-httprequests@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.5.1.tgz#93cb7a73b0ea271f4ac5fe1d8f87dde1603dd98b"
-  integrity sha512-T/+OjfThJFr//goDdrgbuKCqhoWSAwMGL4rCWO9OlFtkagwlssitM0qT0ZzypAtN5/47Mh5aKi7qdS/8c6jy5g==
+"@comunica/mediatortype-accuracy@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-2.8.2.tgz#a569ff4bcb16016cdfbaa3d3c3147cffa1b17a70"
+  integrity sha512-VWHhtoAhIQvwVGxWW2G75dzcnd8QIaeSSm4IAuVjteUniuXdUoktvCI1GH4kyVw/HUfVmFwslDrGs8rUh+uPKQ==
   dependencies:
-    "@comunica/core" "^2.5.1"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/mediatortype-join-coefficients@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-2.5.1.tgz#9a68a8e0b844542ffc7c47c2d17ba277f3b86720"
-  integrity sha512-NrdQNXw9dIsJZCDrydTW/EzT11X2u9DD7kXoE/cbLL77nqWCK0S9EE3cvZjpgmXRt/Q8ZlaVvC6IcUqrU4SW1Q==
+"@comunica/mediatortype-httprequests@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.8.2.tgz#a0973fa85029844dc9f2a6b3665bca202185beda"
+  integrity sha512-ftYYMcPNHHORpeSFFCmeBXfmZuNUeFCJS1DGkLrjMfHufDvyFpMaU1WrOXDwa8y0g9UvF5V12O7To9WcE5FPhg==
   dependencies:
-    "@comunica/core" "^2.5.1"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/mediatortype-join-coefficients@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-2.8.2.tgz#29b9735e1f0dd8b26b162589dedb928cf07dc6b2"
+  integrity sha512-nvu+WPs1048U19YUBBZsR8UDs+fmTVGrc2cRHiSW1w6EkcgMnIMV9OR6pvmSZAoy4XNcZb8hbV4nS+ETYb7yqw==
+  dependencies:
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
 "@comunica/mediatortype-time@^2.5.1":
@@ -2069,152 +2462,177 @@
   dependencies:
     "@comunica/core" "^2.5.1"
 
-"@comunica/query-sparql@^2.2.1":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@comunica/query-sparql/-/query-sparql-2.5.2.tgz#841dcc738d38459f18a674ba0046e506034bcb7a"
-  integrity sha512-ZUqKB23Qouq5rew5Ef/u5xMkqGJ9J/G4SQSE633uiMcIz8oVWLYFTbCuqOfnmQZ3gmct+B2szuFmyBvlH8hJkQ==
+"@comunica/mediatortype-time@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-time/-/mediatortype-time-2.8.2.tgz#c0232b9b66fcd2b7214366974bd5543c651395ad"
+  integrity sha512-ZNApJwoE5iwO9o1GGYhjYzJeNmkvWggiNGkvYyRvua0HrMa3fXzZJSzU5I9Dkoh3lzfNsgPemoO+vg/SiH8WyA==
   dependencies:
-    "@comunica/actor-context-preprocess-source-to-destination" "^2.5.1"
-    "@comunica/actor-dereference-fallback" "^2.5.1"
-    "@comunica/actor-dereference-http" "^2.5.1"
-    "@comunica/actor-dereference-rdf-parse" "^2.5.1"
-    "@comunica/actor-hash-bindings-sha1" "^2.5.1"
-    "@comunica/actor-http-fetch" "^2.5.1"
-    "@comunica/actor-http-proxy" "^2.5.1"
-    "@comunica/actor-http-wayback" "^2.5.1"
-    "@comunica/actor-init-query" "^2.5.1"
-    "@comunica/actor-optimize-query-operation-bgp-to-join" "^2.5.1"
-    "@comunica/actor-optimize-query-operation-join-bgp" "^2.5.1"
-    "@comunica/actor-optimize-query-operation-join-connected" "^2.5.1"
-    "@comunica/actor-query-operation-ask" "^2.5.1"
-    "@comunica/actor-query-operation-bgp-join" "^2.5.1"
-    "@comunica/actor-query-operation-construct" "^2.5.1"
-    "@comunica/actor-query-operation-describe-subject" "^2.5.1"
-    "@comunica/actor-query-operation-distinct-hash" "^2.5.1"
-    "@comunica/actor-query-operation-extend" "^2.5.1"
-    "@comunica/actor-query-operation-filter-sparqlee" "^2.5.1"
-    "@comunica/actor-query-operation-from-quad" "^2.5.1"
-    "@comunica/actor-query-operation-group" "^2.5.1"
-    "@comunica/actor-query-operation-join" "^2.5.1"
-    "@comunica/actor-query-operation-leftjoin" "^2.5.1"
-    "@comunica/actor-query-operation-minus" "^2.5.1"
-    "@comunica/actor-query-operation-nop" "^2.5.1"
-    "@comunica/actor-query-operation-orderby-sparqlee" "^2.5.1"
-    "@comunica/actor-query-operation-path-alt" "^2.5.1"
-    "@comunica/actor-query-operation-path-inv" "^2.5.1"
-    "@comunica/actor-query-operation-path-link" "^2.5.1"
-    "@comunica/actor-query-operation-path-nps" "^2.5.1"
-    "@comunica/actor-query-operation-path-one-or-more" "^2.5.1"
-    "@comunica/actor-query-operation-path-seq" "^2.5.1"
-    "@comunica/actor-query-operation-path-zero-or-more" "^2.5.1"
-    "@comunica/actor-query-operation-path-zero-or-one" "^2.5.1"
-    "@comunica/actor-query-operation-project" "^2.5.1"
-    "@comunica/actor-query-operation-quadpattern" "^2.5.1"
-    "@comunica/actor-query-operation-reduced-hash" "^2.5.1"
-    "@comunica/actor-query-operation-service" "^2.5.1"
-    "@comunica/actor-query-operation-slice" "^2.5.1"
-    "@comunica/actor-query-operation-sparql-endpoint" "^2.5.1"
-    "@comunica/actor-query-operation-union" "^2.5.1"
-    "@comunica/actor-query-operation-update-add-rewrite" "^2.5.1"
-    "@comunica/actor-query-operation-update-clear" "^2.5.1"
-    "@comunica/actor-query-operation-update-compositeupdate" "^2.5.1"
-    "@comunica/actor-query-operation-update-copy-rewrite" "^2.5.1"
-    "@comunica/actor-query-operation-update-create" "^2.5.1"
-    "@comunica/actor-query-operation-update-deleteinsert" "^2.5.1"
-    "@comunica/actor-query-operation-update-drop" "^2.5.1"
-    "@comunica/actor-query-operation-update-load" "^2.5.1"
-    "@comunica/actor-query-operation-update-move-rewrite" "^2.5.1"
-    "@comunica/actor-query-operation-values" "^2.5.1"
-    "@comunica/actor-query-parse-graphql" "^2.5.1"
-    "@comunica/actor-query-parse-sparql" "^2.5.1"
-    "@comunica/actor-query-result-serialize-json" "^2.5.1"
-    "@comunica/actor-query-result-serialize-rdf" "^2.5.1"
-    "@comunica/actor-query-result-serialize-simple" "^2.5.1"
-    "@comunica/actor-query-result-serialize-sparql-csv" "^2.5.1"
-    "@comunica/actor-query-result-serialize-sparql-json" "^2.5.1"
-    "@comunica/actor-query-result-serialize-sparql-tsv" "^2.5.1"
-    "@comunica/actor-query-result-serialize-sparql-xml" "^2.5.1"
-    "@comunica/actor-query-result-serialize-stats" "^2.5.1"
-    "@comunica/actor-query-result-serialize-table" "^2.5.1"
-    "@comunica/actor-query-result-serialize-tree" "^2.5.2"
-    "@comunica/actor-rdf-join-entries-sort-cardinality" "^2.5.1"
-    "@comunica/actor-rdf-join-inner-hash" "^2.5.1"
-    "@comunica/actor-rdf-join-inner-multi-bind" "^2.5.1"
-    "@comunica/actor-rdf-join-inner-multi-empty" "^2.5.1"
-    "@comunica/actor-rdf-join-inner-multi-smallest" "^2.5.1"
-    "@comunica/actor-rdf-join-inner-nestedloop" "^2.5.1"
-    "@comunica/actor-rdf-join-inner-none" "^2.5.1"
-    "@comunica/actor-rdf-join-inner-single" "^2.5.1"
-    "@comunica/actor-rdf-join-inner-symmetrichash" "^2.5.1"
-    "@comunica/actor-rdf-join-minus-hash" "^2.5.1"
-    "@comunica/actor-rdf-join-minus-hash-undef" "^2.5.1"
-    "@comunica/actor-rdf-join-optional-bind" "^2.5.1"
-    "@comunica/actor-rdf-join-optional-nestedloop" "^2.5.1"
-    "@comunica/actor-rdf-join-selectivity-variable-counting" "^2.5.1"
-    "@comunica/actor-rdf-metadata-all" "^2.5.1"
-    "@comunica/actor-rdf-metadata-extract-allow-http-methods" "^2.5.1"
-    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^2.5.1"
-    "@comunica/actor-rdf-metadata-extract-hydra-count" "^2.5.1"
-    "@comunica/actor-rdf-metadata-extract-hydra-pagesize" "^2.5.1"
-    "@comunica/actor-rdf-metadata-extract-patch-sparql-update" "^2.5.1"
-    "@comunica/actor-rdf-metadata-extract-put-accepted" "^2.5.1"
-    "@comunica/actor-rdf-metadata-extract-request-time" "^2.5.1"
-    "@comunica/actor-rdf-metadata-extract-sparql-service" "^2.5.1"
-    "@comunica/actor-rdf-metadata-primary-topic" "^2.5.1"
-    "@comunica/actor-rdf-parse-html" "^2.5.1"
-    "@comunica/actor-rdf-parse-html-microdata" "^2.5.1"
-    "@comunica/actor-rdf-parse-html-rdfa" "^2.5.1"
-    "@comunica/actor-rdf-parse-html-script" "^2.5.1"
-    "@comunica/actor-rdf-parse-jsonld" "^2.5.1"
-    "@comunica/actor-rdf-parse-n3" "^2.5.1"
-    "@comunica/actor-rdf-parse-rdfxml" "^2.5.1"
-    "@comunica/actor-rdf-parse-xml-rdfa" "^2.5.1"
-    "@comunica/actor-rdf-resolve-hypermedia-links-next" "^2.5.1"
-    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo" "^2.5.1"
-    "@comunica/actor-rdf-resolve-hypermedia-none" "^2.5.1"
-    "@comunica/actor-rdf-resolve-hypermedia-qpf" "^2.5.1"
-    "@comunica/actor-rdf-resolve-hypermedia-sparql" "^2.5.1"
-    "@comunica/actor-rdf-resolve-quad-pattern-federated" "^2.5.1"
-    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia" "^2.5.1"
-    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source" "^2.5.1"
-    "@comunica/actor-rdf-resolve-quad-pattern-string-source" "^2.5.1"
-    "@comunica/actor-rdf-serialize-jsonld" "^2.5.1"
-    "@comunica/actor-rdf-serialize-n3" "^2.5.1"
-    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update" "^2.5.1"
-    "@comunica/actor-rdf-update-hypermedia-put-ldp" "^2.5.1"
-    "@comunica/actor-rdf-update-hypermedia-sparql" "^2.5.1"
-    "@comunica/actor-rdf-update-quads-hypermedia" "^2.5.1"
-    "@comunica/actor-rdf-update-quads-rdfjs-store" "^2.5.1"
-    "@comunica/bus-http-invalidate" "^2.5.1"
-    "@comunica/config-query-sparql" "^2.5.1"
-    "@comunica/core" "^2.5.1"
-    "@comunica/logger-void" "^2.5.1"
-    "@comunica/mediator-all" "^2.5.1"
-    "@comunica/mediator-combine-pipeline" "^2.5.1"
-    "@comunica/mediator-combine-union" "^2.5.1"
-    "@comunica/mediator-join-coefficients-fixed" "^2.5.1"
-    "@comunica/mediator-number" "^2.5.1"
-    "@comunica/mediator-race" "^2.5.1"
-    "@comunica/runner" "^2.5.1"
-    "@comunica/runner-cli" "^2.5.1"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/runner-cli@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/runner-cli/-/runner-cli-2.5.1.tgz#d0b198e97f131b5ead0cbb1fec26cbfd3fda45fc"
-  integrity sha512-NYNVR/Xjwo2opYvQ2ilJMWFmaOkccQnuVr3KUxF36lAPK5b3I5YmLM/aQUV34n5/uUZJJgAgwmgsH5kQb0Numw==
+"@comunica/metadata@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/metadata/-/metadata-2.8.2.tgz#1c8eafa5f3c4eaa1bd4cac4db680f062b813f712"
+  integrity sha512-/yznxjOo+/6yJkdb45wfWig5waIhAv+qKd79D2EAt26EAy43thBXgGORxDTOx8vULPG3ij5SIDcNRZ7vJwJO8Q==
   dependencies:
-    "@comunica/core" "^2.5.1"
-    "@comunica/runner" "^2.5.1"
-    "@comunica/types" "^2.5.1"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/runner@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/runner/-/runner-2.5.1.tgz#66278b5973d22ab6ec83a4c07003bf8af15446c2"
-  integrity sha512-WXnO6/g3KXdH3Bga0aq1zvvPxXtUvveurRhAX43u+Py4DCW4M5GCQoo4SEPtLS0XrPxNeIsQy3ofP2Rz9BTi/A==
+"@comunica/query-sparql@^2.6.9":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@comunica/query-sparql/-/query-sparql-2.8.3.tgz#b8755a36aa6c663a5ba7e5dfc093fcc9b5488174"
+  integrity sha512-MebbF1iZFAuHY7w7IpkGruVBV2TDWfQIcnPVcnHSXrB8tIMXbB8g4vtSUIqGxeSl7Q6ghcFh8eMxWGSzwaSloQ==
   dependencies:
-    "@comunica/bus-init" "^2.5.1"
-    "@comunica/core" "^2.5.1"
+    "@comunica/actor-context-preprocess-source-to-destination" "^2.8.2"
+    "@comunica/actor-dereference-fallback" "^2.8.2"
+    "@comunica/actor-dereference-http" "^2.8.2"
+    "@comunica/actor-dereference-rdf-parse" "^2.8.2"
+    "@comunica/actor-hash-bindings-sha1" "^2.8.2"
+    "@comunica/actor-http-fetch" "^2.8.2"
+    "@comunica/actor-http-proxy" "^2.8.2"
+    "@comunica/actor-http-wayback" "^2.8.2"
+    "@comunica/actor-init-query" "^2.8.2"
+    "@comunica/actor-optimize-query-operation-bgp-to-join" "^2.8.2"
+    "@comunica/actor-optimize-query-operation-join-bgp" "^2.8.2"
+    "@comunica/actor-optimize-query-operation-join-connected" "^2.8.2"
+    "@comunica/actor-query-operation-ask" "^2.8.2"
+    "@comunica/actor-query-operation-bgp-join" "^2.8.2"
+    "@comunica/actor-query-operation-construct" "^2.8.2"
+    "@comunica/actor-query-operation-describe-subject" "^2.8.2"
+    "@comunica/actor-query-operation-distinct-hash" "^2.8.2"
+    "@comunica/actor-query-operation-extend" "^2.8.3"
+    "@comunica/actor-query-operation-filter-sparqlee" "^2.8.3"
+    "@comunica/actor-query-operation-from-quad" "^2.8.2"
+    "@comunica/actor-query-operation-group" "^2.8.2"
+    "@comunica/actor-query-operation-join" "^2.8.2"
+    "@comunica/actor-query-operation-leftjoin" "^2.8.2"
+    "@comunica/actor-query-operation-minus" "^2.8.2"
+    "@comunica/actor-query-operation-nop" "^2.8.2"
+    "@comunica/actor-query-operation-orderby-sparqlee" "^2.8.2"
+    "@comunica/actor-query-operation-path-alt" "^2.8.2"
+    "@comunica/actor-query-operation-path-inv" "^2.8.2"
+    "@comunica/actor-query-operation-path-link" "^2.8.2"
+    "@comunica/actor-query-operation-path-nps" "^2.8.2"
+    "@comunica/actor-query-operation-path-one-or-more" "^2.8.2"
+    "@comunica/actor-query-operation-path-seq" "^2.8.2"
+    "@comunica/actor-query-operation-path-zero-or-more" "^2.8.2"
+    "@comunica/actor-query-operation-path-zero-or-one" "^2.8.2"
+    "@comunica/actor-query-operation-project" "^2.8.2"
+    "@comunica/actor-query-operation-quadpattern" "^2.8.2"
+    "@comunica/actor-query-operation-reduced-hash" "^2.8.2"
+    "@comunica/actor-query-operation-service" "^2.8.2"
+    "@comunica/actor-query-operation-slice" "^2.8.2"
+    "@comunica/actor-query-operation-sparql-endpoint" "^2.8.2"
+    "@comunica/actor-query-operation-union" "^2.8.2"
+    "@comunica/actor-query-operation-update-add-rewrite" "^2.8.2"
+    "@comunica/actor-query-operation-update-clear" "^2.8.2"
+    "@comunica/actor-query-operation-update-compositeupdate" "^2.8.2"
+    "@comunica/actor-query-operation-update-copy-rewrite" "^2.8.2"
+    "@comunica/actor-query-operation-update-create" "^2.8.2"
+    "@comunica/actor-query-operation-update-deleteinsert" "^2.8.2"
+    "@comunica/actor-query-operation-update-drop" "^2.8.2"
+    "@comunica/actor-query-operation-update-load" "^2.8.2"
+    "@comunica/actor-query-operation-update-move-rewrite" "^2.8.2"
+    "@comunica/actor-query-operation-values" "^2.8.2"
+    "@comunica/actor-query-parse-graphql" "^2.8.2"
+    "@comunica/actor-query-parse-sparql" "^2.8.2"
+    "@comunica/actor-query-result-serialize-json" "^2.8.2"
+    "@comunica/actor-query-result-serialize-rdf" "^2.8.2"
+    "@comunica/actor-query-result-serialize-simple" "^2.8.2"
+    "@comunica/actor-query-result-serialize-sparql-csv" "^2.8.2"
+    "@comunica/actor-query-result-serialize-sparql-json" "^2.8.2"
+    "@comunica/actor-query-result-serialize-sparql-tsv" "^2.8.2"
+    "@comunica/actor-query-result-serialize-sparql-xml" "^2.8.2"
+    "@comunica/actor-query-result-serialize-stats" "^2.8.2"
+    "@comunica/actor-query-result-serialize-table" "^2.8.2"
+    "@comunica/actor-query-result-serialize-tree" "^2.8.2"
+    "@comunica/actor-rdf-join-entries-sort-cardinality" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-hash" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-multi-bind" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-multi-empty" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-multi-smallest" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-nestedloop" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-none" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-single" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-symmetrichash" "^2.8.2"
+    "@comunica/actor-rdf-join-minus-hash" "^2.8.2"
+    "@comunica/actor-rdf-join-minus-hash-undef" "^2.8.2"
+    "@comunica/actor-rdf-join-optional-bind" "^2.8.2"
+    "@comunica/actor-rdf-join-optional-nestedloop" "^2.8.2"
+    "@comunica/actor-rdf-join-selectivity-variable-counting" "^2.8.2"
+    "@comunica/actor-rdf-metadata-accumulate-cancontainundefs" "^2.8.2"
+    "@comunica/actor-rdf-metadata-accumulate-cardinality" "^2.8.2"
+    "@comunica/actor-rdf-metadata-accumulate-pagesize" "^2.8.2"
+    "@comunica/actor-rdf-metadata-accumulate-requesttime" "^2.8.2"
+    "@comunica/actor-rdf-metadata-all" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-allow-http-methods" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-hydra-count" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-hydra-pagesize" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-patch-sparql-update" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-put-accepted" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-request-time" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-sparql-service" "^2.8.2"
+    "@comunica/actor-rdf-metadata-primary-topic" "^2.8.2"
+    "@comunica/actor-rdf-parse-html" "^2.8.2"
+    "@comunica/actor-rdf-parse-html-microdata" "^2.8.2"
+    "@comunica/actor-rdf-parse-html-rdfa" "^2.8.2"
+    "@comunica/actor-rdf-parse-html-script" "^2.8.2"
+    "@comunica/actor-rdf-parse-jsonld" "^2.8.2"
+    "@comunica/actor-rdf-parse-n3" "^2.8.2"
+    "@comunica/actor-rdf-parse-rdfxml" "^2.8.2"
+    "@comunica/actor-rdf-parse-shaclc" "^2.8.2"
+    "@comunica/actor-rdf-parse-xml-rdfa" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-links-next" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-none" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-qpf" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-sparql" "^2.8.3"
+    "@comunica/actor-rdf-resolve-quad-pattern-federated" "^2.8.2"
+    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia" "^2.8.3"
+    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source" "^2.8.2"
+    "@comunica/actor-rdf-resolve-quad-pattern-string-source" "^2.8.2"
+    "@comunica/actor-rdf-serialize-jsonld" "^2.8.2"
+    "@comunica/actor-rdf-serialize-n3" "^2.8.2"
+    "@comunica/actor-rdf-serialize-shaclc" "^2.8.2"
+    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update" "^2.8.2"
+    "@comunica/actor-rdf-update-hypermedia-put-ldp" "^2.8.2"
+    "@comunica/actor-rdf-update-hypermedia-sparql" "^2.8.2"
+    "@comunica/actor-rdf-update-quads-hypermedia" "^2.8.2"
+    "@comunica/actor-rdf-update-quads-rdfjs-store" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.8.2"
+    "@comunica/config-query-sparql" "^2.7.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/logger-void" "^2.8.2"
+    "@comunica/mediator-all" "^2.8.2"
+    "@comunica/mediator-combine-pipeline" "^2.8.2"
+    "@comunica/mediator-combine-union" "^2.8.2"
+    "@comunica/mediator-join-coefficients-fixed" "^2.8.2"
+    "@comunica/mediator-number" "^2.8.2"
+    "@comunica/mediator-race" "^2.8.2"
+    "@comunica/runner" "^2.8.2"
+    "@comunica/runner-cli" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    process "^0.11.10"
+
+"@comunica/runner-cli@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/runner-cli/-/runner-cli-2.8.2.tgz#64aab0402ab5dc4f84cb41da1ffa21bbbb7b6757"
+  integrity sha512-FB7ciWt8YTKy1pFDNgdDCgJirPQ6tGk6xIhnpwo/vQ7cyRwIAddXOfOHCGdEqyOLFO/57PD7PB2G3GjhEJTu1Q==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/runner" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    process "^0.11.10"
+
+"@comunica/runner@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/runner/-/runner-2.8.2.tgz#453b0b0d18414165a72695bb923b237867ef3564"
+  integrity sha512-a6DzNfPT6k5zdesuytEZ7BjqShlwQoZIovqUguty49+NRIP6KbYkCousQlgYWY2uKNazmjJaSYIO6QWCJBJ7Fg==
+  dependencies:
+    "@comunica/bus-init" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     componentsjs "^5.3.2"
+    process "^0.11.10"
 
 "@comunica/types@^2.5.1":
   version "2.5.1"
@@ -2235,6 +2653,16 @@
     "@types/yargs" "^17.0.13"
     asynciterator "^3.8.0"
     sparqlalgebrajs "^4.0.5"
+
+"@comunica/types@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/types/-/types-2.8.2.tgz#b910c1ed767118958184e47432c9cc47e9c4c884"
+  integrity sha512-gF/wlBtr0Q1VVozYna7DLYlIU528vqinpc0MJ67uvFALJJHP9uqhjOsmVokdoEirf1WIut5GkEp33IGyBvOv5Q==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@types/yargs" "^17.0.13"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.3"
@@ -2606,7 +3034,40 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@rdfjs/types@*", "@rdfjs/types@^1.1.0":
+"@rdfjs/data-model@^1.1.0", "@rdfjs/data-model@^1.2.0":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@rdfjs/data-model/-/data-model-1.3.4.tgz#2b1b3e52755ab1283bf66aa2d3ac97fd8a0332c2"
+  integrity sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==
+  dependencies:
+    "@rdfjs/types" ">=1.0.1"
+
+"@rdfjs/dataset@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@rdfjs/dataset/-/dataset-1.1.1.tgz#0a91746284c517eba360a966939161f500392107"
+  integrity sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==
+  dependencies:
+    "@rdfjs/data-model" "^1.2.0"
+
+"@rdfjs/namespace@^1.0.0", "@rdfjs/namespace@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@rdfjs/namespace/-/namespace-1.1.0.tgz#869cb9a9f37c4ab4c0a03b603baeb0b95487609f"
+  integrity sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==
+  dependencies:
+    "@rdfjs/data-model" "^1.1.0"
+
+"@rdfjs/term-set@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@rdfjs/term-set/-/term-set-1.1.0.tgz#36adb73683262e94f135f0bb0cdf71d983e70960"
+  integrity sha512-QQ4yzVe1Rvae/GN9SnOhweHNpaxQtnAjeOVciP/yJ0Gfxtbphy2tM56ZsRLV04Qq5qMcSclZIe6irYyEzx/UwQ==
+  dependencies:
+    "@rdfjs/to-ntriples" "^2.0.0"
+
+"@rdfjs/to-ntriples@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz#ad70822e2ddf068fd1291b505e5c678c17af7a30"
+  integrity sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q==
+
+"@rdfjs/types@*", "@rdfjs/types@>=1.0.1", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==
@@ -2634,6 +3095,13 @@
     eslint-plugin-unicorn "37.0.1"
     eslint-plugin-unused-imports "^2.0.0"
 
+"@rubensworks/saxes@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@rubensworks/saxes/-/saxes-6.0.1.tgz#2f394548493a415c522d2bfd4f12fad67c9a6317"
+  integrity sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==
+  dependencies:
+    xmlchars "^2.2.0"
+
 "@rushstack/eslint-patch@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
@@ -2658,7 +3126,12 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@solid/access-token-verifier@^2.0.3":
+"@solid/access-control-policy@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@solid/access-control-policy/-/access-control-policy-0.1.3.tgz#e95f97b5f8e203295843ca20ffd7da36f96ae8a6"
+  integrity sha512-LTxfN8N5hNBNYfuwJr0nyfxlp2P0+GeK+biCa1FQgIqska3wXpTgYaxjVgsw27mKx4N1FOlaGwG+nXdLnl9ykg==
+
+"@solid/access-token-verifier@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@solid/access-token-verifier/-/access-token-verifier-2.0.5.tgz#e731768bcb88f45eb299b9d60e4eec9667364a1f"
   integrity sha512-YsoMmEk7pN6tlCHcDm5iLa9ZYvTYvuk3SX5cz18XW1qYmM46znEGnXz94vm7DIa7DcTLGi9suMw7M5pRs2xOLw==
@@ -2669,72 +3142,77 @@
     node-fetch "^2.6.7"
     ts-guards "^0.5.1"
 
-"@solid/community-server@^5.0.0-alpha.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@solid/community-server/-/community-server-5.1.0.tgz#164b70dca51c4ba744f6d24183ed95ceee498b5b"
-  integrity sha512-i0ANCJeumuM6hm6/iYV8viMA3z69CWVpy5U3k+Sr1QUWDqIBM/HSpOwlmn9HI917qJeTxkAgnCPGYVTXl3WS1Q==
+"@solid/community-server@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@solid/community-server/-/community-server-6.0.2.tgz#91b6990ec7a2c2af163378d81ada081c98a5385e"
+  integrity sha512-freTs6jp+LtqtPCnjdWlUK23U1WhwcuxeyQ+JHhIv9HTlMonGWaMoRzQIAhXxxYm07Y9rjN7OLnw8uSRPbyPeQ==
   dependencies:
-    "@comunica/context-entries" "^2.2.0"
-    "@comunica/query-sparql" "^2.2.1"
+    "@comunica/context-entries" "^2.6.8"
+    "@comunica/query-sparql" "^2.6.9"
     "@rdfjs/types" "^1.1.0"
-    "@solid/access-token-verifier" "^2.0.3"
-    "@types/async-lock" "^1.1.5"
+    "@solid/access-control-policy" "^0.1.3"
+    "@solid/access-token-verifier" "^2.0.5"
+    "@types/async-lock" "^1.4.0"
     "@types/bcryptjs" "^2.4.2"
     "@types/cors" "^2.8.12"
-    "@types/ejs" "^3.1.1"
+    "@types/ejs" "^3.1.2"
     "@types/end-of-stream" "^1.4.1"
-    "@types/fs-extra" "^9.0.13"
+    "@types/fs-extra" "^11.0.1"
     "@types/lodash.orderby" "^4.6.7"
-    "@types/marked" "^4.0.3"
+    "@types/marked" "^4.0.8"
     "@types/mime-types" "^2.1.1"
     "@types/n3" "^1.10.4"
-    "@types/node" "^14.18.23"
-    "@types/nodemailer" "^6.4.4"
+    "@types/node" "^14.18.43"
+    "@types/nodemailer" "^6.4.7"
     "@types/oidc-provider" "^7.11.1"
     "@types/proper-lockfile" "^4.1.2"
     "@types/pump" "^1.1.1"
     "@types/punycode" "^2.1.0"
-    "@types/sparqljs" "^3.1.3"
+    "@types/rdf-validate-shacl" "^0.4.1"
+    "@types/sparqljs" "^3.1.4"
     "@types/url-join" "^4.0.1"
-    "@types/uuid" "^8.3.4"
-    "@types/ws" "^8.5.3"
-    "@types/yargs" "^17.0.10"
-    arrayify-stream "^2.0.0"
-    async-lock "^1.3.2"
+    "@types/uuid" "^9.0.1"
+    "@types/ws" "^8.5.4"
+    "@types/yargs" "^17.0.24"
+    arrayify-stream "^2.0.1"
+    async-lock "^1.4.0"
     bcryptjs "^2.4.3"
-    componentsjs "^5.3.0"
+    componentsjs "^5.3.2"
     cors "^2.8.5"
     cross-fetch "^3.1.5"
-    ejs "^3.1.8"
+    ejs "^3.1.9"
     end-of-stream "^1.4.4"
     escape-string-regexp "^4.0.0"
-    fetch-sparql-endpoint "^3.0.1"
-    fs-extra "^10.1.0"
+    fetch-sparql-endpoint "^3.2.1"
+    fs-extra "^11.1.1"
     handlebars "^4.7.7"
-    ioredis "^5.2.2"
-    jose "^4.8.3"
-    jsonld-context-parser "^2.1.5"
+    ioredis "^5.3.2"
+    iso8601-duration "^2.1.1"
+    jose "^4.14.1"
+    jsonld-context-parser "^2.3.0"
     lodash.orderby "^4.6.0"
-    marked "^4.0.18"
+    marked "^4.3.0"
     mime-types "^2.1.35"
-    n3 "^1.16.2"
-    nodemailer "^6.7.7"
+    n3 "^1.16.4"
+    nodemailer "^6.9.1"
     oidc-provider "7.10.6"
     proper-lockfile "^4.1.2"
     pump "^3.0.0"
     punycode "^2.1.1"
-    rdf-dereference "^2.0.0"
-    rdf-parse "^2.1.0"
-    rdf-serialize "^2.0.0"
-    rdf-terms "^1.9.0"
-    sparqlalgebrajs "^4.0.3"
-    sparqljs "^3.5.2"
+    rdf-dereference "^2.1.0"
+    rdf-parse "^2.3.2"
+    rdf-serialize "^2.2.2"
+    rdf-string "^1.6.3"
+    rdf-terms "^1.9.1"
+    rdf-validate-shacl "^0.4.5"
+    sparqlalgebrajs "^4.0.5"
+    sparqljs "^3.6.2"
     url-join "^4.0.1"
-    uuid "^8.3.2"
-    winston "^3.8.1"
+    uuid "^9.0.0"
+    winston "^3.8.2"
     winston-transport "^4.5.0"
-    ws "^8.8.1"
-    yargs "^17.5.1"
+    ws "^8.13.0"
+    yargs "^17.7.1"
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -2755,10 +3233,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/async-lock@^1.1.2", "@types/async-lock@^1.1.5":
+"@types/async-lock@^1.1.2":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/async-lock/-/async-lock-1.3.0.tgz#12d165b890935afbc553eb9db467c0b540658b8e"
   integrity sha512-Z93wDSYW9aMgPR5t+7ouwTvy91Vp3M0Snh4Pd3tf+caSAq5bXZaGnnH9CDbjrwgmfDkRIX0Dx8GvSDgwuoaxoA==
+
+"@types/async-lock@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/async-lock/-/async-lock-1.4.0.tgz#e7d555d037f93e911d54000acb626e783ff9023a"
+  integrity sha512-2+rYSaWrpdbQG3SA0LmMT6YxWLrI81AqpMlSkw3QtFc2HGDufkweQSn30Eiev7x9LL0oyFrBqk1PXOnB9IEgKg==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.20"
@@ -2816,6 +3299,13 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
+"@types/clownface@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/clownface/-/clownface-2.0.0.tgz#e3d8d6faf0d5807b0a5103b05e275feac0ba1da1"
+  integrity sha512-4rvgWFPLPJPQHGXy5BXowDO7hvMKXVlED8ItXkUcNv4kvTnQ7q3UQeVYuJyT46JdxRdHU9hvqpHbIAJyPQUycw==
+  dependencies:
+    rdf-js "^4.0.2"
+
 "@types/connect@*":
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
@@ -2859,10 +3349,10 @@
     "@types/docker-modem" "*"
     "@types/node" "*"
 
-"@types/ejs@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.1.1.tgz#29c539826376a65e7f7d672d51301f37ed718f6d"
-  integrity sha512-RQul5wEfY7BjWm0sYY86cmUN/pcXWGyVxWX93DFFJvcrxax5zKlieLwA3T77xJGwNcZW0YW6CYG70p1m8xPFmA==
+"@types/ejs@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.1.2.tgz#75d277b030bc11b3be38c807e10071f45ebc78d9"
+  integrity sha512-ZmiaE3wglXVWBM9fyVC17aGPkLo/UgaOjEiI2FXQfyczrCefORPxIe+2dVmnmk3zkVIbizjrlQzmPGhSYGXG5g==
 
 "@types/end-of-stream@^1.4.1":
   version "1.4.1"
@@ -2889,6 +3379,14 @@
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
+
+"@types/fs-extra@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.1.tgz#f542ec47810532a8a252127e6e105f487e0a6ea5"
+  integrity sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==
+  dependencies:
+    "@types/jsonfile" "*"
+    "@types/node" "*"
 
 "@types/fs-extra@^9.0.13":
   version "9.0.13"
@@ -2971,6 +3469,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/jsonfile@*":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.1.tgz#ac84e9aefa74a2425a0fb3012bdea44f58970f1b"
+  integrity sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==
+  dependencies:
+    "@types/node" "*"
+
 "@types/keygrip@*":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.2.tgz#513abfd256d7ad0bf1ee1873606317b33b1b2a72"
@@ -3021,10 +3526,17 @@
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
   integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
 
-"@types/marked@^4.0.3":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.7.tgz#400a76809fd08c2bbd9e25f3be06ea38c8e0a1d3"
-  integrity sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw==
+"@types/lru-cache@^7.0.0":
+  version "7.10.10"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-7.10.10.tgz#3fa937c35ff4b3f6753d5737915c9bf8e693a713"
+  integrity sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==
+  dependencies:
+    lru-cache "*"
+
+"@types/marked@^4.0.8":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.3.1.tgz#45fb6dfd47afb595766c71ed7749ead23f137de3"
+  integrity sha512-vSSbKZFbNktrQ15v7o1EaH78EbWV+sPQbPjHG+Cp8CaNcPFUEfjZ0Iml/V0bFDwsTlYe8o6XC5Hfdp91cqPV2g==
 
 "@types/mime-types@^2.1.1":
   version "2.1.1"
@@ -3061,15 +3573,20 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
-"@types/node@^14.14.7", "@types/node@^14.18.23":
+"@types/node@^14.14.7":
   version "14.18.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.33.tgz#8c29a0036771569662e4635790ffa9e057db379b"
   integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
 
-"@types/nodemailer@^6.4.4":
-  version "6.4.6"
-  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.6.tgz#ce21b4b474a08f672f182e15982b7945dde1f288"
-  integrity sha512-pD6fL5GQtUKvD2WnPmg5bC2e8kWCAPDwMPmHe/ohQbW+Dy0EcHgZ2oCSuPlWNqk74LS5BVMig1SymQbFMPPK3w==
+"@types/node@^14.18.43":
+  version "14.18.56"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.56.tgz#09e092d684cd8cfbdb3c5e5802672712242f2600"
+  integrity sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==
+
+"@types/nodemailer@^6.4.7":
+  version "6.4.9"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.9.tgz#38e22cc2e62006170df0966fb8762fbf5cec6cbf"
+  integrity sha512-XYG8Gv+sHjaOtUpiuytahMy2mM3rectgroNbs6R3djZEKmPNiIJwe9KqOJBGzKKnNZNKvnuvmugBgpq3w/S0ig==
   dependencies:
     "@types/node" "*"
 
@@ -3124,7 +3641,15 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/readable-stream@^2.3.11", "@types/readable-stream@^2.3.13":
+"@types/rdf-validate-shacl@^0.4.1":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@types/rdf-validate-shacl/-/rdf-validate-shacl-0.4.2.tgz#828dc83dda9de14096b5ee3bf85596d8f5b76354"
+  integrity sha512-txAtt8VBUMp6tO41aeJtbf6sgvM1n1LTC7rhmfO9ili7eoAe0wlNXGjo+1RLtb9pHWe9s2SnRAxFFbOY5A5I/A==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@types/clownface" "*"
+
+"@types/readable-stream@^2.3.11", "@types/readable-stream@^2.3.13", "@types/readable-stream@^2.3.15":
   version "2.3.15"
   resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-2.3.15.tgz#3d79c9ceb1b6a57d5f6e6976f489b9b5384321ae"
   integrity sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==
@@ -3169,6 +3694,13 @@
   dependencies:
     rdf-js "^4.0.2"
 
+"@types/sparqljs@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/sparqljs/-/sparqljs-3.1.4.tgz#1600733caaf07ad487792aadbc9b0574b05f6228"
+  integrity sha512-0MvCTEfveYJDkI91olLcDf/F3wMMbsxwNxiNZeglt4tbIFULd9pRpcacj1MuA+acFDkTnPXS9L7OqZNn/W1MAg==
+  dependencies:
+    rdf-js "^4.0.2"
+
 "@types/ssh2@*":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@types/ssh2/-/ssh2-1.11.6.tgz#c114d15a3cfd2ba2f7ef219a2020c44f0fb8a01b"
@@ -3203,15 +3735,20 @@
   resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.1.tgz#4989c97f969464647a8586c7252d97b449cdc045"
   integrity sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==
 
-"@types/uuid@^8.0.0", "@types/uuid@^8.3.4":
+"@types/uuid@^8.0.0":
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
-"@types/ws@^8.5.3":
-  version "8.5.3"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
-  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+"@types/uuid@^9.0.1":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.2.tgz#ede1d1b1e451548d44919dc226253e32a6952c4b"
+  integrity sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==
+
+"@types/ws@^8.5.4":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.5.tgz#af587964aa06682702ee6dcbc7be41a80e4b28eb"
+  integrity sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==
   dependencies:
     "@types/node" "*"
 
@@ -3241,10 +3778,17 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^17.0.10", "@types/yargs@^17.0.13":
+"@types/yargs@^17.0.13":
   version "17.0.14"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.14.tgz#0943473052c24bd8cf2d1de25f1a710259327237"
   integrity sha512-9Pj7abXoW1RSTcZaL2Hk6G2XyLMlp5ECdVC/Zf2p/KBjC3srijLGgRAXOBjtFrJoIrvxdTKyKDA14bEcbxBaWw==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.24":
+  version "17.0.24"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.24.tgz#b3ef8d50ad4aa6aecf6ddc97c580a00f5aa11902"
+  integrity sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3704,7 +4248,7 @@ arrayify-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/arrayify-stream/-/arrayify-stream-1.0.0.tgz#9e8e113d43325c3a44e965c59b5b89d962b9a37f"
   integrity sha512-RP80ep76Lbew2wWN5ogrl2NluTnBVYYh2K3NNCcWfcmmUB7nBcNBctiJeEZAixp3I1vQ9H88iHZ9MbHSdkuupQ==
 
-arrayify-stream@^2.0.0, arrayify-stream@^2.0.1:
+arrayify-stream@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrayify-stream/-/arrayify-stream-2.0.1.tgz#1981e419a7aa7ddc6b6a7b46ef86e10785425f81"
   integrity sha512-z8fB6PtmnewQpFB53piS2d1KlUi3BPMICH2h7leCOUXpQcwvZ4GbHHSpdKoUrgLMR6b4Qan/uDe1St3Ao3yIHg==
@@ -3741,7 +4285,7 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-async-lock@^1.2.4, async-lock@^1.3.2:
+async-lock@^1.2.4, async-lock@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.0.tgz#c8b6630eff68fbbdd8a5b6eb763dac3bfbb8bf02"
   integrity sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==
@@ -3755,6 +4299,11 @@ asynciterator@^3.6.0, asynciterator@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/asynciterator/-/asynciterator-3.8.0.tgz#d9246a3d39ce2a9e4b020834d7f352adf35b49d8"
   integrity sha512-bD34LqKHJnkB77MHjL3hOAUOcy9dbB+3lHvL+EiJpD3k2Nyq3i1dCk5adMisB2rwlrHVu/+XRhOdPZL9hzpsfw==
+
+asynciterator@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/asynciterator/-/asynciterator-3.8.1.tgz#80be735b252332494e186ee733544e5b21dd2123"
+  integrity sha512-SmdG0FUY3pYGOZZGdYq8Qb/DCRDXBFZUk08V1/4lbBXdAQvcC3Kxzz9FUDPBTik7VAVltt4cZirAPtJv3gOpEw==
 
 asyncjoin@^1.1.1:
   version "1.1.1"
@@ -4112,10 +4661,15 @@ caniuse-lite@^1.0.30001400:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz#ec1ec1cfb0a93a34a0600d37903853030520a4e5"
   integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
 
-canonicalize@^1.0.1, canonicalize@^1.0.8:
+canonicalize@^1.0.1:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.8.tgz#24d1f1a00ed202faafd9bf8e63352cd4450c6df1"
   integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
+
+canonicalize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-2.0.0.tgz#32be2cef4446d67fd5348027a384cae28f17226a"
+  integrity sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4246,6 +4800,14 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clownface@^1.4.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/clownface/-/clownface-1.5.1.tgz#5471f462aa8a5945ad878305b832361214424759"
+  integrity sha512-Ko8N/UFsnhEGmPlyE1bUFhbRhVgDbxqlIjcqxtLysc4dWaY0A7iCdg3savhAxs7Lheb7FCygIyRh7ADYZWVIng==
+  dependencies:
+    "@rdfjs/data-model" "^1.1.0"
+    "@rdfjs/namespace" "^1.0.0"
+
 cluster-key-slot@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
@@ -4334,7 +4896,7 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-componentsjs@^5.0.1, componentsjs@^5.3.0, componentsjs@^5.3.2:
+componentsjs@^5.0.1, componentsjs@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/componentsjs/-/componentsjs-5.3.2.tgz#0b95c85e4184406cc7913142d65136c9b9e3f2c1"
   integrity sha512-wqXaHjrnT4UDQT8Eaou/Itd55OWE7wasBivPJ0qfSlRMi5zRAwp3+sEgGO7F5T7hs0rMsrGTnkWWcoSHmrM/8A==
@@ -4443,6 +5005,13 @@ cross-fetch@^3.0.6, cross-fetch@^3.1.5:
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
   dependencies:
     node-fetch "2.6.7"
+
+cross-fetch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
+  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  dependencies:
+    node-fetch "^2.6.12"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -4620,7 +5189,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
-denque@^2.0.1:
+denque@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
   integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
@@ -4716,7 +5285,7 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-domhandler@^5.0.1, domhandler@^5.0.2:
+domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
@@ -4731,6 +5300,15 @@ domutils@^3.0.1:
     dom-serializer "^2.0.0"
     domelementtype "^2.3.0"
     domhandler "^5.0.1"
+
+domutils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 duplexer2@~0.1.4:
   version "0.1.4"
@@ -4752,10 +5330,17 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@^3.1.6, ejs@^3.1.8:
+ejs@^3.1.6:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
   integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
+
+ejs@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
+  integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
   dependencies:
     jake "^10.8.5"
 
@@ -4807,6 +5392,11 @@ entities@^4.2.0, entities@^4.3.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+
+entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -5495,10 +6085,10 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
-fetch-sparql-endpoint@^3.0.1, fetch-sparql-endpoint@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.1.1.tgz#08cc3cc8bc5e59a6b45250fcee1fb306fcea5264"
-  integrity sha512-SWb/d70+VTQmS+7th1ZgT05Kx6RMCsBoLv//oO29SObqDfzU0amxJ0EdMvoIKRgxWsbpZX423aS/NWHK1VhAIg==
+fetch-sparql-endpoint@^3.2.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.3.3.tgz#7b1fda7f980564fd62945ca880664d68c6994b93"
+  integrity sha512-5ZNesFhFMcsEiSaCyg36L5VU7YP7xMJogc5i0n00nFNFZzrfGJ4Cm8LGrzXI6eySkb7QmaRyNWJGk5btAOjniA==
   dependencies:
     "@rdfjs/types" "*"
     "@types/readable-stream" "^2.3.11"
@@ -5511,8 +6101,28 @@ fetch-sparql-endpoint@^3.0.1, fetch-sparql-endpoint@^3.1.1:
     rdf-string "^1.6.0"
     readable-web-to-node-stream "^3.0.2"
     sparqljs "^3.1.2"
-    sparqljson-parse "^2.1.0"
-    sparqlxml-parse "^2.0.0"
+    sparqljson-parse "^2.2.0"
+    sparqlxml-parse "^2.1.1"
+    stream-to-string "^1.1.0"
+
+fetch-sparql-endpoint@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-4.0.0.tgz#5a604b13d8c94eb96993610897f95876a8ba5c0f"
+  integrity sha512-32a1Oa5rW513iwzKLmd9Y5UaJCk5PPwUF4H64Vw4Z0IjppMTX6aFqFeijLGuVPyV+mbqGFY43ZaePzjJMKnTqg==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@types/readable-stream" "^2.3.11"
+    "@types/sparqljs" "^3.1.3"
+    abort-controller "^3.0.0"
+    cross-fetch "^3.0.6"
+    is-stream "^2.0.0"
+    minimist "^1.2.0"
+    n3 "^1.6.3"
+    rdf-string "^1.6.0"
+    readable-web-to-node-stream "^3.0.2"
+    sparqljs "^3.1.2"
+    sparqljson-parse "^2.2.0"
+    sparqlxml-parse "^2.1.1"
     stream-to-string "^1.1.0"
 
 figures@^3.0.0:
@@ -5664,6 +6274,15 @@ fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -6049,6 +6668,16 @@ htmlparser2@^8.0.0, htmlparser2@^8.0.1:
     domutils "^3.0.1"
     entities "^4.3.0"
 
+htmlparser2@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.0.0.tgz#e431142b7eeb1d91672742dea48af8ac7140cddb"
+  integrity sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    entities "^4.5.0"
+
 http-assert@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.5.0.tgz#c389ccd87ac16ed2dfa6246fd73b926aa00e6b8f"
@@ -6243,15 +6872,15 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-ioredis@^5.2.2:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.2.4.tgz#9e262a668bc29bae98f2054c1e0d7efd86996b96"
-  integrity sha512-qIpuAEt32lZJQ0XyrloCRdlEdUUNGG9i0UOk6zgzK6igyudNWqEBxfH6OlbnOOoBBvr1WB02mm8fR55CnikRng==
+ioredis@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.3.2.tgz#9139f596f62fc9c72d873353ac5395bcf05709f7"
+  integrity sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==
   dependencies:
     "@ioredis/commands" "^1.1.1"
     cluster-key-slot "^1.1.0"
     debug "^4.3.4"
-    denque "^2.0.1"
+    denque "^2.1.0"
     lodash.defaults "^4.2.0"
     lodash.isarguments "^3.1.0"
     redis-errors "^1.2.0"
@@ -6531,6 +7160,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+iso8601-duration@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/iso8601-duration/-/iso8601-duration-2.1.1.tgz#88d9e481525b50e57840bc93fb8a1727a7d849d2"
+  integrity sha512-VGGpW30/R57FpG1J7RqqKBAaK7lIiudlZkQ5tRoO9hNlKYQNnhs60DQpXlPFBmp6I+kJ61PHkI3f/T7cR4wfbw==
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -7056,10 +7690,15 @@ jju@~1.4.0:
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
 
-jose@^4.1.4, jose@^4.10.3, jose@^4.8.3:
+jose@^4.1.4, jose@^4.10.3:
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.11.1.tgz#8f7443549befe5bddcf4bae664a9cbc1a62da4fa"
   integrity sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==
+
+jose@^4.14.1:
+  version "4.14.4"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.14.4.tgz#59e09204e2670c3164ee24cbfe7115c6f8bff9ca"
+  integrity sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -7178,10 +7817,22 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonld-context-parser@^2.0.0, jsonld-context-parser@^2.0.2, jsonld-context-parser@^2.1.1, jsonld-context-parser@^2.1.3, jsonld-context-parser@^2.1.5, jsonld-context-parser@^2.2.2:
+jsonld-context-parser@^2.0.0, jsonld-context-parser@^2.0.2, jsonld-context-parser@^2.1.1, jsonld-context-parser@^2.1.3, jsonld-context-parser@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/jsonld-context-parser/-/jsonld-context-parser-2.2.2.tgz#2c206b022eddd335bb7477046e1bd6dfb4322c34"
   integrity sha512-3VWIg/4NCMTXP6NsI6O93spFTd4qIOucKEmD8I+Exhxk9ZUVrnkLp2G4f0toR5jVleZkiiB9YGPS+yT1wwMqnQ==
+  dependencies:
+    "@types/http-link-header" "^1.0.1"
+    "@types/node" "^18.0.0"
+    canonicalize "^1.0.1"
+    cross-fetch "^3.0.6"
+    http-link-header "^1.0.2"
+    relative-to-absolute-iri "^1.0.5"
+
+jsonld-context-parser@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/jsonld-context-parser/-/jsonld-context-parser-2.3.0.tgz#423a36114bd7876477dabef105efe49cc79fb59b"
+  integrity sha512-c6w2GE57O26eWFjcPX6k6G86ootsIfpuVwhZKjCll0bVoDGBxr1P4OuU+yvgfnh1GJhAGErolfC7W1BklLjWMg==
   dependencies:
     "@types/http-link-header" "^1.0.1"
     "@types/node" "^18.0.0"
@@ -7206,7 +7857,7 @@ jsonld-streaming-parser@^3.0.1:
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
 
-jsonld-streaming-serializer@^2.0.1:
+jsonld-streaming-serializer@^2.0.1, jsonld-streaming-serializer@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz#db80d6e13d74ae5837a313123ea4d409b04df2e0"
   integrity sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==
@@ -7463,6 +8114,11 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@*, lru-cache@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
+  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -7522,10 +8178,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^4.0.18:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.3.tgz#bd76a5eb510ff1d8421bc6c3b2f0b93488c15bea"
-  integrity sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -7712,10 +8368,18 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-n3@^1.11.1, n3@^1.16.2, n3@^1.16.3, n3@^1.6.3:
+n3@^1.16.2, n3@^1.16.3, n3@^1.6.3:
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.16.3.tgz#d339dca14c79648b1595a3252c5410b800b896f8"
   integrity sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==
+  dependencies:
+    queue-microtask "^1.1.2"
+    readable-stream "^4.0.0"
+
+n3@^1.16.4, n3@^1.17.0:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-1.17.1.tgz#cb42f39507cebebf2c990c2f8a3f5f53232c518c"
+  integrity sha512-HlanMWpvN2kcTrFuU3GPObyY7qrVQWy2Hp7l4GSXJlcQapjQMR7OM4kCr788pTQzNIpiHS3JRvyZ2YUcYJ82rA==
   dependencies:
     queue-microtask "^1.1.2"
     readable-stream "^4.0.0"
@@ -7784,6 +8448,13 @@ node-fetch@2.6.7, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -7806,10 +8477,10 @@ node-releases@^2.0.6:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
   integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
 
-nodemailer@^6.7.7:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.8.0.tgz#804bcc5256ee5523bc914506ee59f8de8f0b1cd5"
-  integrity sha512-EjYvSmHzekz6VNkNd12aUqAco+bOkRe3Of5jVhltqKhEsjw/y0PYPJfp83+s9Wzh1dspYAkUW/YNQ350NATbSQ==
+nodemailer@^6.9.1:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.4.tgz#93bd4a60eb0be6fa088a0483340551ebabfd2abf"
+  integrity sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -8375,6 +9046,13 @@ rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1:
   dependencies:
     "@rdfjs/types" "*"
 
+rdf-data-factory@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz#d47550d2649d0d64f8cae3fcc9efae7a8a895d9a"
+  integrity sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==
+  dependencies:
+    "@rdfjs/types" "*"
+
 rdf-dataset-fragmenter@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/rdf-dataset-fragmenter/-/rdf-dataset-fragmenter-2.3.6.tgz#ff3aed14e07ffcd00edbdcefc388d6e7561c32ad"
@@ -8394,15 +9072,15 @@ rdf-dataset-fragmenter@^2.3.5:
     rdf-terms "^1.8.2"
     relative-to-absolute-iri "^1.0.6"
 
-rdf-dereference@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/rdf-dereference/-/rdf-dereference-2.0.1.tgz#7650fad0d959889463325e3d43cb8d061730bf91"
-  integrity sha512-iiVAljvo4a/k48/TvqdHOTPmL83IBjYyRWizZQQZa50nGCvbbIvdh24LpvZQVF1g3fOB+SpGUktJAqQoUTt7Rw==
+rdf-dereference@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rdf-dereference/-/rdf-dereference-2.2.0.tgz#948971eb32e6b6b0e519c1286913612ae1022c43"
+  integrity sha512-6geM3CSUlXTK3n4OoKsL95M7XwKXoxiwK7cf4e/+Dj0X/ll77ihFN5j9VhLGXNYbMXDlm30kBg/VU6ymMv6o/Q==
   dependencies:
     "@comunica/actor-dereference-fallback" "^2.0.2"
     "@comunica/actor-dereference-file" "^2.0.2"
     "@comunica/actor-dereference-http" "^2.0.2"
-    "@comunica/actor-dereference-rdf-parse" "^2.0.2"
+    "@comunica/actor-dereference-rdf-parse" "^2.6.0"
     "@comunica/actor-http-fetch" "^2.0.1"
     "@comunica/actor-http-proxy" "^2.0.1"
     "@comunica/actor-rdf-parse-html" "^2.0.1"
@@ -8412,6 +9090,7 @@ rdf-dereference@^2.0.0:
     "@comunica/actor-rdf-parse-jsonld" "^2.0.1"
     "@comunica/actor-rdf-parse-n3" "^2.0.1"
     "@comunica/actor-rdf-parse-rdfxml" "^2.0.1"
+    "@comunica/actor-rdf-parse-shaclc" "^2.6.0"
     "@comunica/actor-rdf-parse-xml-rdfa" "^2.0.1"
     "@comunica/bus-dereference" "^2.0.2"
     "@comunica/bus-dereference-rdf" "^2.0.2"
@@ -8420,12 +9099,14 @@ rdf-dereference@^2.0.0:
     "@comunica/bus-rdf-parse" "^2.0.1"
     "@comunica/bus-rdf-parse-html" "^2.0.1"
     "@comunica/config-query-sparql" "^2.0.1"
+    "@comunica/context-entries" "^2.8.1"
     "@comunica/core" "^2.0.1"
     "@comunica/mediator-combine-pipeline" "^2.0.1"
     "@comunica/mediator-combine-union" "^2.0.1"
     "@comunica/mediator-number" "^2.0.1"
     "@comunica/mediator-race" "^2.0.1"
     "@rdfjs/types" "*"
+    process "^0.11.10"
     rdf-string "^1.6.0"
     stream-to-string "^1.2.0"
 
@@ -8446,7 +9127,7 @@ rdf-js@^4.0.2:
   dependencies:
     "@rdfjs/types" "*"
 
-rdf-literal@^1.2.0:
+rdf-literal@^1.2.0, rdf-literal@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/rdf-literal/-/rdf-literal-1.3.1.tgz#07db05d4a92e1b8b3dd491a4499648872c6d96ee"
   integrity sha512-+o/PGOfJchyay9Rjrvi/oveRJACnt2WFO3LhEvtPlsRD1tFmwVUCMU+s33FtQprMo+z1ohFrv/yfEQ6Eym4KgQ==
@@ -8465,7 +9146,7 @@ rdf-object@^1.13.1:
     rdf-string "^1.6.0"
     streamify-array "^1.0.1"
 
-rdf-parse@^2.0.0, rdf-parse@^2.1.0:
+rdf-parse@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/rdf-parse/-/rdf-parse-2.1.1.tgz#c80d1cd8f3ca8d01d9c7b7d056f73316e2f4edd1"
   integrity sha512-JOTB7381bAdvab9ZM8IZq6Egj9tuTt7XSGlrQzDCFrlAjvc7z4cMxKawgk1kZaoS/CevNSrHYsyEaBwgNyl1KA==
@@ -8491,6 +9172,36 @@ rdf-parse@^2.0.0, rdf-parse@^2.1.0:
     "@comunica/mediator-number" "^2.0.1"
     "@comunica/mediator-race" "^2.0.1"
     "@rdfjs/types" "*"
+    stream-to-string "^1.2.0"
+
+rdf-parse@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/rdf-parse/-/rdf-parse-2.3.2.tgz#83539491f7e348f34d314c585a18f0ba707e2368"
+  integrity sha512-TOeI7FKlyr/GupfGaXZvpMLzvByOrtwt4zHLMuuy3deNGse9QyhHsspVraZam491sIgBogdchzcUqkf2WXnAsg==
+  dependencies:
+    "@comunica/actor-http-fetch" "^2.0.1"
+    "@comunica/actor-http-proxy" "^2.0.1"
+    "@comunica/actor-rdf-parse-html" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-microdata" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-rdfa" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-script" "^2.0.1"
+    "@comunica/actor-rdf-parse-jsonld" "^2.0.1"
+    "@comunica/actor-rdf-parse-n3" "^2.0.1"
+    "@comunica/actor-rdf-parse-rdfxml" "^2.0.1"
+    "@comunica/actor-rdf-parse-shaclc" "^2.6.2"
+    "@comunica/actor-rdf-parse-xml-rdfa" "^2.0.1"
+    "@comunica/bus-http" "^2.0.1"
+    "@comunica/bus-init" "^2.0.1"
+    "@comunica/bus-rdf-parse" "^2.0.1"
+    "@comunica/bus-rdf-parse-html" "^2.0.1"
+    "@comunica/config-query-sparql" "^2.0.1"
+    "@comunica/core" "^2.0.1"
+    "@comunica/mediator-combine-pipeline" "^2.0.1"
+    "@comunica/mediator-combine-union" "^2.0.1"
+    "@comunica/mediator-number" "^2.0.1"
+    "@comunica/mediator-race" "^2.0.1"
+    "@rdfjs/types" "*"
+    readable-stream "^4.3.0"
     stream-to-string "^1.2.0"
 
 rdf-quad@^1.5.0:
@@ -8537,13 +9248,56 @@ rdf-serialize@^2.2.1:
     "@rdfjs/types" "*"
     stream-to-string "^1.1.0"
 
-rdf-store-stream@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/rdf-store-stream/-/rdf-store-stream-1.3.1.tgz#41045dd0a403135d767459d64ec3ec449f77e16e"
-  integrity sha512-+cpnGKJMwFbCa/L0fogSMrNA95P+T2tSoWWXj94IdGN2UdYu+oQpaP7vav5wGenWQ1J9/nQu6Sy0m+stNfAZFw==
+rdf-serialize@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/rdf-serialize/-/rdf-serialize-2.2.2.tgz#9e91faec392a281c435f8864c9ee300594825aa2"
+  integrity sha512-zzWQMMMmDzocuFLEOcdz8U5AxbdjBvknwFEHXCyw2lklcEjd2OtsvD5NgWQc+zbsWZKxewvDYEXuzhkNAHRv1g==
+  dependencies:
+    "@comunica/actor-rdf-serialize-jsonld" "^2.6.6"
+    "@comunica/actor-rdf-serialize-n3" "^2.6.6"
+    "@comunica/actor-rdf-serialize-shaclc" "^2.6.0"
+    "@comunica/bus-init" "^2.0.1"
+    "@comunica/bus-rdf-serialize" "^2.0.1"
+    "@comunica/config-query-sparql" "^2.0.1"
+    "@comunica/core" "^2.0.1"
+    "@comunica/mediator-combine-pipeline" "^2.0.1"
+    "@comunica/mediator-combine-union" "^2.0.1"
+    "@comunica/mediator-race" "^2.0.1"
+    "@rdfjs/types" "*"
+    readable-stream "^4.3.0"
+    stream-to-string "^1.1.0"
+
+rdf-store-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-store-stream/-/rdf-store-stream-2.0.0.tgz#941932d4f20859a93e495586d2bd501aa0408f2f"
+  integrity sha512-FKRsA5XUdhFVMx+jg4JCBM76B4ZcXVKyilr8GJrlfkHB2IZSIgLxY2XHIsewkDfm/yAtXHvPT0PaeQg4Mbqa6g==
   dependencies:
     "@rdfjs/types" "*"
-    n3 "^1.11.1"
+    rdf-stores "^1.0.0"
+
+rdf-stores@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-stores/-/rdf-stores-1.0.0.tgz#1689bd669853bda857620d0db32f3b59940db208"
+  integrity sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==
+  dependencies:
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.0"
+    rdf-data-factory "^1.1.1"
+    rdf-string "^1.6.2"
+    rdf-terms "^1.9.1"
+
+rdf-streaming-store@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rdf-streaming-store/-/rdf-streaming-store-1.1.0.tgz#a00be02eeb1616e577a095dad9afe96d9106fcfa"
+  integrity sha512-C/5NTKGpKrNJ5VUo42DtGFsXYDlP3rx/u4C6gEBuSn+6eVFahjFdUDgNGcPtVyhCQkctRCj3GT1lX9UeyoXWtw==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@types/n3" "^1.10.4"
+    "@types/readable-stream" "^2.3.15"
+    n3 "^1.16.3"
+    rdf-string "^1.6.2"
+    rdf-terms "^1.9.1"
+    readable-stream "^4.3.0"
 
 rdf-string-ttl@^1.3.2:
   version "1.3.2"
@@ -8561,7 +9315,24 @@ rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-terms@^1.7.0, rdf-terms@^1.8.2, rdf-terms@^1.9.0, rdf-terms@^1.9.1:
+rdf-string@^1.6.2, rdf-string@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.3.tgz#5c3173fad13e6328698277fb8ff151e3423282ab"
+  integrity sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+
+rdf-terms@^1.10.0, rdf-terms@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.11.0.tgz#0c2e3a2b43f1042959c9263af27dab08dc4b084d"
+  integrity sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+    rdf-string "^1.6.0"
+
+rdf-terms@^1.7.0, rdf-terms@^1.8.2, rdf-terms@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.9.1.tgz#5f66a773d4b2fe6e071ebc8a2985beff7e0dfd7f"
   integrity sha512-GrE8CbQSvuVEFRCywMu6VOgV1AFE6X+nFYcAhEc5pwYKI13bUvz4voiVufQiy3V8rzQKu21Sgl+dS2qcJavy7w==
@@ -8569,6 +9340,27 @@ rdf-terms@^1.7.0, rdf-terms@^1.8.2, rdf-terms@^1.9.0, rdf-terms@^1.9.1:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
     rdf-string "^1.6.0"
+
+rdf-validate-datatype@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/rdf-validate-datatype/-/rdf-validate-datatype-0.1.5.tgz#1ebfe4a506aa7ff55e6c20eb4d559e55cf3936d7"
+  integrity sha512-gU+cD+AT1LpFwbemuEmTDjwLyFwJDiw21XHyIofKhFnEpXODjShBuxhgDGnZqW3qIEwu/vECjOecuD60e5ngiQ==
+  dependencies:
+    "@rdfjs/namespace" "^1.1.0"
+    "@rdfjs/to-ntriples" "^2.0.0"
+
+rdf-validate-shacl@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/rdf-validate-shacl/-/rdf-validate-shacl-0.4.5.tgz#a95e92e22ff45c9ffd5131229c3cb08a4a5c668e"
+  integrity sha512-tGYnssuPzmsPua1dju4hEtGkT1zouvwzVTNrFhNiqj2aZFO5pQ7lvLd9Cv9H9vKAlpIdC/x0zL6btxG3PCss0w==
+  dependencies:
+    "@rdfjs/dataset" "^1.1.1"
+    "@rdfjs/namespace" "^1.0.0"
+    "@rdfjs/term-set" "^1.1.0"
+    clownface "^1.4.0"
+    debug "^4.3.2"
+    rdf-literal "^1.3.0"
+    rdf-validate-datatype "^0.1.5"
 
 rdfa-streaming-parser@^2.0.1:
   version "2.0.1"
@@ -8593,6 +9385,20 @@ rdfxml-streaming-parser@^2.2.1:
     readable-stream "^4.0.0"
     relative-to-absolute-iri "^1.0.0"
     saxes "^6.0.0"
+    validate-iri "^1.0.0"
+
+rdfxml-streaming-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.3.tgz#ca362b5557068b37334e44790912e7ca5b089a1a"
+  integrity sha512-HoH8urnga+YQ5sDY9ufRb0wg6FvwR284sSXpZ+fJE5X5Oej6dfzkFer81uBNZzyNmzJR1TpMYMznyXEjPMLhCA==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@rubensworks/saxes" "^6.0.1"
+    "@types/readable-stream" "^2.3.13"
+    buffer "^6.0.3"
+    rdf-data-factory "^1.1.0"
+    readable-stream "^4.0.0"
+    relative-to-absolute-iri "^1.0.0"
     validate-iri "^1.0.0"
 
 react-is@^16.13.1, react-is@^16.8.4:
@@ -9053,6 +9859,14 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+shaclc-parse@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-1.4.0.tgz#1a82643daf0f7309ca8722d9bee4ee40f2726925"
+  integrity sha512-zyxjIYQH2ghg/wtMvOp+4Nr6aK8j9bqFiVT3w47K8WHPYN+S3Zgnh2ybT+dGgMwo9KjiOoywxhjC7d8Z6GCmfA==
+  dependencies:
+    "@rdfjs/types" "^1.1.0"
+    n3 "^1.16.3"
+
 shaclc-write@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/shaclc-write/-/shaclc-write-1.4.2.tgz#1262e30d40da3353858e67f0972330bcef498418"
@@ -9230,7 +10044,7 @@ sparql-query-parameter-instantiator@^2.3.0, sparql-query-parameter-instantiator@
     csv-parser "^3.0.0"
     sparqljs "^3.4.1"
 
-sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.3, sparqlalgebrajs@^4.0.5:
+sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz#054cd4dbbe9c2e2ecc345948fd5a7cfad1d475a4"
   integrity sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==
@@ -9244,10 +10058,25 @@ sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.3, sparqlalgebrajs@^4.0.5:
     rdf-string "^1.6.0"
     sparqljs "^3.6.1"
 
-sparqlee@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-2.1.0.tgz#4949c50d1c16ca0113e657ebb138cd85d630c9c0"
-  integrity sha512-4ElqFxcq1TKXGt4V37nSsQGoGBPqdZUftTd6w2s1iY9QtZosEAXcMelJ6i78vdwqWdSXTMSV7m4cQodp8219EQ==
+sparqlalgebrajs@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.2.0.tgz#b70945bdd2ab2897a0bc22adb804dd1a2b0ec98c"
+  integrity sha512-tdlJdrvgQqgx9zubcl9iiyCxMOp4qRT2fs1Sne8X35QTm1Pj2ulB+gGEHunJJnw5FW7Uhtmw7J3px0sCmgJSbw==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@types/sparqljs" "^3.1.3"
+    fast-deep-equal "^3.1.3"
+    minimist "^1.2.6"
+    rdf-data-factory "^1.1.0"
+    rdf-isomorphic "^1.3.0"
+    rdf-string "^1.6.0"
+    rdf-terms "^1.10.0"
+    sparqljs "^3.7.1"
+
+sparqlee@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-3.0.1.tgz#9a496d27783d2a4d4f4ac804f315f711d0337e00"
+  integrity sha512-Iq7t+yi23cD8D0/TIUNr4S6vGmECM5j/ceBbJSWDNmnwM+74OEwx764FjY7BjLqnyEaBPLuA3rsvGoL084Uy9w==
   dependencies:
     "@comunica/bindings-factory" "^2.0.1"
     "@rdfjs/types" "^1.1.0"
@@ -9257,21 +10086,28 @@ sparqlee@^2.1.0:
     bignumber.js "^9.0.1"
     hash.js "^1.1.7"
     lru-cache "^6.0.0"
-    rdf-data-factory "^1.1.0"
-    rdf-string "^1.6.0"
+    rdf-data-factory "^1.1.2"
+    rdf-string "^1.6.3"
     relative-to-absolute-iri "^1.0.6"
     spark-md5 "^3.0.1"
-    sparqlalgebrajs "^4.0.0"
+    sparqlalgebrajs "^4.2.0"
     uuid "^8.0.0"
 
-sparqljs@^3.1.2, sparqljs@^3.4.1, sparqljs@^3.5.2, sparqljs@^3.6.1:
+sparqljs@^3.1.2, sparqljs@^3.4.1, sparqljs@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.6.1.tgz#9aa6d07afbce2b95edfcd83403fac09b3ab51f73"
   integrity sha512-4QoI3cMywOio8mtTLa3Rl85XI7UBvQRm1CbzbHEQ7C6AN6ldBFsSS96vkhcKCQKPl0eDTmCXsi+50234+1cOpA==
   dependencies:
     rdf-data-factory "^1.1.1"
 
-sparqljson-parse@^2.0.0, sparqljson-parse@^2.1.0:
+sparqljs@^3.6.2, sparqljs@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.1.tgz#5d121895d491d50214f2e38f2885a3a935b6c093"
+  integrity sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==
+  dependencies:
+    rdf-data-factory "^1.1.2"
+
+sparqljson-parse@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-2.1.2.tgz#e727724ca8c9e6bc979f0d15c550d862f6ae3003"
   integrity sha512-RqPeyy+RYQMeqgEsKPTY+ME5ZNXcgXJzg1v0o+tROiTntS9CwUW8mAY3wsx6seSvW3LVyNDEtsqOxnAokoGXOA==
@@ -9283,6 +10119,17 @@ sparqljson-parse@^2.0.0, sparqljson-parse@^2.1.0:
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
 
+sparqljson-parse@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz#58c788e896f7d2c0d3079452d8812943049d4a7e"
+  integrity sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==
+  dependencies:
+    "@bergos/jsonparse" "^1.4.1"
+    "@rdfjs/types" "*"
+    "@types/readable-stream" "^2.3.13"
+    rdf-data-factory "^1.1.0"
+    readable-stream "^4.0.0"
+
 sparqljson-to-tree@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/sparqljson-to-tree/-/sparqljson-to-tree-3.0.1.tgz#bbb8c34aff366555e2a64ce4e45d82bb95e1c5be"
@@ -9291,17 +10138,17 @@ sparqljson-to-tree@^3.0.1:
     rdf-literal "^1.2.0"
     sparqljson-parse "^2.0.0"
 
-sparqlxml-parse@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/sparqlxml-parse/-/sparqlxml-parse-2.0.2.tgz#e7682b050e90d3cc5f108c31c7cfbb0f559b8b03"
-  integrity sha512-Iqso0WSTCSuMUYoX2pOEJxteCq9U+7AkOqwlFcvFG1S1aM87xWrp28njQOIiyIrL7Y8CkVXBZG1ec+DhZYUNXA==
+sparqlxml-parse@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/sparqlxml-parse/-/sparqlxml-parse-2.1.1.tgz#594a3bf8893bb29062cf1be4b0809937741b22f4"
+  integrity sha512-71sltShF6gDAzuKWEHNeij7r0Mv5VqRrvJing6W4WHJ12GRe6+t1IRTv6MeqxYN3XJmKevs7B3HCBUo7wceeJQ==
   dependencies:
     "@rdfjs/types" "*"
+    "@rubensworks/saxes" "^6.0.1"
     "@types/readable-stream" "^2.3.13"
     buffer "^6.0.3"
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
-    saxes "^6.0.0"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -10027,10 +10874,15 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.0.0, uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -10192,10 +11044,27 @@ winston-transport@^4.5.0:
     readable-stream "^3.6.0"
     triple-beam "^1.3.0"
 
-winston@^3.3.3, winston@^3.8.1:
+winston@^3.3.3:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.8.2.tgz#56e16b34022eb4cff2638196d9646d7430fdad50"
   integrity sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.5.0"
+
+winston@^3.8.2:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.10.0.tgz#d033cb7bd3ced026fed13bf9d92c55b903116803"
+  integrity sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==
   dependencies:
     "@colors/colors" "1.5.0"
     "@dabh/diagnostics" "^2.0.2"
@@ -10264,10 +11133,10 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
-ws@^8.8.1:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
-  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+ws@^8.13.0:
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
+  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
@@ -10352,10 +11221,23 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.5.1, yargs@^17.6.2:
+yargs@^17.6.2:
   version "17.6.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
   integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.7.1:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
The main goal here was to bump the Community Solid Server dependency to version 6, because it was stuck on 5 and 6 has been out for a while now. The latest version of the CSS also allows `.meta` files with `FixedContentTypeMapper`, which makes it possible to add triples to containers themselves for benchmarking purposes. I have adjusted the server configuration in templates to work with the new CSS version.

The other changes in this PR that I wanted to have feedback on (making it a draft) are the following:
* Updating `@rubensworks/eslint-config` to version 2, and removing the dependencies from here that are provided by that package already. Three rules had to be disabled in `.eslintrc.js` after this, but otherwise it seemed to just work.
* Setting `rimraf` to use an actual version rather than `latest`, because the tag was causing some warnings about unpack paths and something being skipped with Yarn version 1.
* Adding Node 18.x to the CI
* Adding `--ignore-engines` to avoid 'package not compatible with Node version' errors
* Adding `--frozen-lockfile` to make sure the CI installs exactly what is in the lockfile.

Any feedback is welcome. I can also remove changes if some of them seem dubious. :slightly_smiling_face: 