### PR TITLE
fix: Missing tagclass objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "dockerode": "^3.2.1",
     "ldbc-snb-enhancer": "^2.5.1",
     "ldbc-snb-validation-generator": "^1.1.0",
-    "rdf-dataset-fragmenter": "^2.3.5",
+    "rdf-dataset-fragmenter": "^2.4.0",
     "sparql-query-parameter-instantiator": "^2.5.1",
     "unzipper": "^0.10.11",
     "yargs": "^16.2.0"

--- a/templates/fragmenter-config-pod.json
+++ b/templates/fragmenter-config-pod.json
@@ -22,6 +22,11 @@
   },
   "transformers": [
     {
+      "@type": "QuadTransformerBlankToNamed",
+      "searchRegex": "^(b[0-9]*_tagclass)",
+      "replacementString": "http://localhost:3000/www.example.org/$1"
+    },
+    {
       "@type": "QuadTransformerReplaceIri",
       "searchRegex": "^http://www.ldbc.eu",
       "replacementString": "http://localhost:3000/www.ldbc.eu"

--- a/templates/fragmenter-config-pod.json
+++ b/templates/fragmenter-config-pod.json
@@ -24,7 +24,7 @@
     {
       "@type": "QuadTransformerBlankToNamed",
       "searchRegex": "^(b[0-9]*_tagclass)",
-      "replacementString": "http://localhost:3000/www.example.org/$1"
+      "replacementString": "http://localhost:3000/www.ldbc.eu/tagclass/$1"
     },
     {
       "@type": "QuadTransformerReplaceIri",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8385,10 +8385,10 @@ rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1, rdf-d
   dependencies:
     "@rdfjs/types" "*"
 
-rdf-dataset-fragmenter@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/rdf-dataset-fragmenter/-/rdf-dataset-fragmenter-2.3.6.tgz#ff3aed14e07ffcd00edbdcefc388d6e7561c32ad"
-  integrity sha512-35GCU4A7qgu3KzgbsLKI5r5m/ZxK8IhnQEu4ysxbXQSVdFZXiF8DZ3LM5qty4YKPHURpmRo0BHYltlge0ePWZQ==
+rdf-dataset-fragmenter@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/rdf-dataset-fragmenter/-/rdf-dataset-fragmenter-2.4.0.tgz#ab0f66984e82fc48178703b0bed11c59775defb6"
+  integrity sha512-2CPBAnymqRFjKJP1zYkhVAJZpK0/VY2rxT+2BsUYFENPOMpiUi6Oz8MEV/oK5ZzGjNhER60XX4oYR839LauovQ==
   dependencies:
     "@rdfjs/types" "*"
     "@types/async-lock" "^1.1.2"


### PR DESCRIPTION
This PR aims to close #9 and depends on https://github.com/SolidBench/rdf-dataset-fragmenter.js/pull/17 . Notice: normal blank nodes get inserted into the same file. This is not possible for the tagclass-typed objects because the objects get referenced from multiple files. To get the same semantics as with the `SNB` `ttl` file, I suggest to translate the blank node to a named one.