### PR TITLE
Use actions/setup-node built-in dependency cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,25 @@
 name: CI
+
 on: [push, pull_request]
+
+env:
+  DEFAULT_NODE_VERSION: 22.x
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
-      - run: corepack enable
-      - run: yarn install --frozen-lockfile --ignore-engines --ignore-scripts
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          cache: yarn
+      - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn run lint
 
   test:
@@ -29,18 +34,13 @@ jobs:
           - 20.x
           - 22.x
     steps:
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: corepack enable
-      - run: git config --global core.autocrlf input
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --frozen-lockfile --ignore-engines
-      - run: yarn run build
+          cache: yarn
+      - run: yarn install  --frozen-lockfile
       - run: yarn run test
       - uses: coverallsapp/github-action@v2
         with:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "tsc",
     "test": "jest",
     "lint": "eslint .",
-    "prepare": "husky",
+    "prepare": "husky && yarn run build",
     "version": "manual-git-changelog onversion"
   },
   "dependencies": {


### PR DESCRIPTION
This is a small PR to use the built-in cache from the Node setup action, like in Comunica.

I will also see what happens when running the CI on MacOS and Windows, if that fails, I will drop it from the PR.