### PR TITLE
Avoid unnecessarily overriding CSS Components.js loader properties

### DIFF
--- a/lib/Server.ts
+++ b/lib/Server.ts
@@ -1,4 +1,3 @@
-import { join } from 'node:path';
 import { AppRunner, type LogLevel } from '@solid/community-server';
 
 /**
@@ -23,8 +22,6 @@ export class Server {
     return new AppRunner().run(
       {
         loaderProperties: {
-          mainModulePath: join(__dirname, '..'),
-          typeChecking: false,
           logLevel: <LogLevel> this.logLevel,
         },
         config: this.configPath,

--- a/test/Server-test.ts
+++ b/test/Server-test.ts
@@ -1,4 +1,3 @@
-import { join } from 'node:path';
 import { Server } from '../lib/Server';
 
 const run = jest.fn();
@@ -28,8 +27,6 @@ describe('Server', () => {
     expect(run).toHaveBeenCalledWith(
       {
         loaderProperties: {
-          mainModulePath: join(__dirname, '..'),
-          typeChecking: false,
           logLevel,
         },
         config: configPath,
@@ -52,8 +49,6 @@ describe('Server', () => {
     expect(run).toHaveBeenCalledWith(
       {
         loaderProperties: {
-          mainModulePath: join(__dirname, '..'),
-          typeChecking: false,
           logLevel,
         },
         config: configPath,


### PR DESCRIPTION
This is a small fix to remove the overrides for Components.js loader properties, since they are not needed in SolidBench as it is. If SolidBench would include additional custom CSS components somehow, then it would make sense, but the defaults in CSS should work okay for these parameters.

This is something I noticed while looking into the remote context lookup errors, but this did not fix that.