### PR TITLE
Restore default SolidBench.js enhancer functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/dockerode": "^3.0.0",
     "@types/unzipper": "^0.10.0",
     "dockerode": "^4.0.0",
-    "ldbc-snb-enhancer": "^2.7.0",
+    "ldbc-snb-enhancer": "^2.7.1",
     "ldbc-snb-validation-generator": "^1.2.0",
     "rdf-dataset-fragmenter": "^2.10.0",
     "sparql-query-parameter-instantiator": "^2.8.0",

--- a/templates/enhancer-similarities-config-pod.json
+++ b/templates/enhancer-similarities-config-pod.json
@@ -26,24 +26,27 @@
       "@type": "EnhancementHandlerVocabulary"
     }
   ],
-  "similarityConfig_personTransformer": {
-    "@type": "TransformerReplaceIri",
-    "searchRegex": "^http://www.ldbc.eu/ldbc_socialnet/1.0/data/pers([0-9]*)$",
-    "replacementString": "http://solidbench-server:3000/pods/$1/profile/card#me"
-  },
-  "similarityConfig_parameterEmitterSimilaritiesPeople": {
-    "@type": "ParameterEmitterCsv",
-    "destinationPath": "out-enhanced/parameters-similarities-people.csv",
-    "separator": ";"
-  },
-  "similarityConfig_parameterEmitterSimilaritiesPosts": {
-    "@type": "ParameterEmitterCsv",
-    "destinationPath": "out-enhanced/parameters-similarities-posts.csv",
-    "separator": ";"
-  },
-  "similarityConfig_parameterEmitterSimilaritiesComments": {
-    "@type": "ParameterEmitterCsv",
-    "destinationPath": "out-enhanced/parameters-similarities-comments.csv",
-    "separator": ";"
+  "similarityConfig":{
+    "@type": "SimilarityConfig",
+    "personTransformer": {
+      "@type": "TransformerReplaceIri",
+      "searchRegex": "^http://www.ldbc.eu/ldbc_socialnet/1.0/data/pers([0-9]*)$",
+      "replacementString": "http://solidbench-server:3000/pods/$1/profile/card#me"
+    },
+    "parameterEmitterSimilaritiesPeople": {
+      "@type": "ParameterEmitterCsv",
+      "destinationPath": "out-enhanced/parameters-similarities-people.csv",
+      "separator": ";"
+    },
+    "parameterEmitterSimilaritiesPosts": {
+      "@type": "ParameterEmitterCsv",
+      "destinationPath": "out-enhanced/parameters-similarities-posts.csv",
+      "separator": ";"
+    },
+    "parameterEmitterSimilaritiesComments": {
+      "@type": "ParameterEmitterCsv",
+      "destinationPath": "out-enhanced/parameters-similarities-comments.csv",
+      "separator": ";"
+    }
   }
 }

--- a/templates/enhancer-similarities-config-pod.json
+++ b/templates/enhancer-similarities-config-pod.json
@@ -26,7 +26,7 @@
       "@type": "EnhancementHandlerVocabulary"
     }
   ],
-  "similarityConfig":{
+  "similarityConfig": {
     "@type": "SimilarityConfig",
     "personTransformer": {
       "@type": "TransformerReplaceIri",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7942,10 +7942,10 @@ kuler@^2.0.0:
   resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
   integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
 
-ldbc-snb-enhancer@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/ldbc-snb-enhancer/-/ldbc-snb-enhancer-2.7.0.tgz#cedd60b466abba5ddd57dc204fb978cae43041c5"
-  integrity sha512-OgI2/h+TNQNot1T4P1afBtEeG4XxfFuG41DsG0F3jAfd28+g3v5eRWhC0h5HrhagqVtDps5VyVfxffL73dZlmQ==
+ldbc-snb-enhancer@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/ldbc-snb-enhancer/-/ldbc-snb-enhancer-2.7.1.tgz#0f5982921118a2a42d2f91f11f0679869fd2aaf6"
+  integrity sha512-ZBm7i4TzZPRO6yznyDhq9vOJUM6Hfwii2wZkr4ALDrdvK/GGEs0I1/MQ62mOYWVYxOIQ/D7rYf6AKMqAjSU/4w==
   dependencies:
     "@rdfjs/types" "*"
     componentsjs "^6.0.0"


### PR DESCRIPTION
The previous update broke default SolidBench due to interface flattening by the components-generator. This PR uses the fixed enhancer and updates the default SolidSessionBench enhancer to reflect this update.